### PR TITLE
Make timers persistent

### DIFF
--- a/src/units/cron-daily.timer
+++ b/src/units/cron-daily.timer
@@ -5,5 +5,6 @@ RefuseManualStart=true
 RefuseManualStop=true
 
 [Timer]
+Persistent=true
 OnCalendar=daily
 Unit=cron-daily.target

--- a/src/units/cron-hourly.timer
+++ b/src/units/cron-hourly.timer
@@ -5,5 +5,6 @@ RefuseManualStart=true
 RefuseManualStop=true
 
 [Timer]
+Persistent=true
 OnCalendar=hourly
 Unit=cron-hourly.target

--- a/src/units/cron-monthly.timer
+++ b/src/units/cron-monthly.timer
@@ -5,5 +5,6 @@ RefuseManualStart=true
 RefuseManualStop=true
 
 [Timer]
+Persistent=true
 OnCalendar=monthly
 Unit=cron-monthly.target

--- a/src/units/cron-weekly.timer
+++ b/src/units/cron-weekly.timer
@@ -5,5 +5,6 @@ RefuseManualStart=true
 RefuseManualStop=true
 
 [Timer]
+Persistent=true
 OnCalendar=weekly
 Unit=cron-weekly.target


### PR DESCRIPTION
Systemd 212 added a persistent flag to timers.

`man systemd.timer`:

> Persistent=
>  Takes a boolean argument. If true the service unit is immediately triggered when the timer unit is activated and the timer elapsed at least once since the last time the service unit has been triggered by the timer unit. The time when the service unit was last triggered is stored on disk. This is useful to catch up for missed timers when a machine is shutdown temporarily and then is powered up again. Note that this setting only has an effect on timers configured with OnCalendar=.
