### PR TITLE
don't overide SHELL in env. unless it is explicitely requested

### DIFF
--- a/src/bin/systemd-crontab-generator
+++ b/src/bin/systemd-crontab-generator
@@ -36,7 +36,6 @@ except OSError as e:
 def parse_crontab(filename, withuser=True, monotonic=False):
     basename = os.path.basename(filename)
     environment = {
-        'SHELL': '/bin/sh',
         'PATH': '/usr/bin:/bin',
         }
     random_delay = 1
@@ -76,7 +75,7 @@ def parse_crontab(filename, withuser=True, monotonic=False):
 
                 yield {
                         'e': ' '.join('"%s=%s"' % kv for kv in environment.items()),
-                        's': environment['SHELL'],
+                        's': environment.get('SHELL','/bin/sh'),
                         'a': random_delay,
                         'l': line,
                         'f': filename,
@@ -102,7 +101,7 @@ def parse_crontab(filename, withuser=True, monotonic=False):
 
                     yield {
                             'e': ' '.join('"%s=%s"' % kv for kv in environment.items()),
-                            's': environment['SHELL'],
+                            's': environment.get('SHELL','/bin/sh'),
                             'a': random_delay,
                             'l': line,
                             'f': filename,
@@ -121,7 +120,7 @@ def parse_crontab(filename, withuser=True, monotonic=False):
 
                     yield {
                             'e': ' '.join('"%s=%s"' % kv for kv in environment.items()),
-                            's': environment['SHELL'],
+                            's': environment.get('SHELL','/bin/sh'),
                             'a': random_delay,
                             'l': line,
                             'f': filename,


### PR DESCRIPTION
@schaal 

Hi, I saw in [man:systemd.exec(5)](http://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment%20variables%20in%20spawned%20processes)
that some variables are allways set by systemd itself, so it's not needed to set them in the generated service files .

This little change would only set this environement variable if explicitely requested in a crontab.

This amends this:
https://github.com/kstep/systemd-crontab-generator/commit/ff6968ace6ba254dbeb76beea89f4a4b386689d2
