### PR TITLE
Only manipulate the shell command for known shells.

### DIFF
--- a/src/bin/systemd-crontab-generator
+++ b/src/bin/systemd-crontab-generator
@@ -15,6 +15,7 @@ DOWS_SET = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 MONTHS_SET = list(range(0, 13))
 TIME_UNITS_SET = ['daily', 'weekly', 'monthly', 'quarterly', 'semi-annually', 'yearly']
 
+KSH_SHELLS = ['/bin/sh', '/bin/dash', '/bin/ksh', '/bin/bash', '/usr/bin/zsh']
 REBOOT_FILE = '/run/crond.reboot'
 
 def files(dirname):
@@ -200,46 +201,48 @@ def generate_timer_unit(job, seq):
         home = ''
         pass
 
-    if home and command[0:2] == '~/':
-        command = home + command[1:]
+    # perform smart substitutions for known shells
+    if job['s'] in KSH_SHELLS:
+        if home and command.startswith('~/'):
+            command = home + command[1:]
 
-    if (len(parts) >= 3 and
-        parts[-2] == '>' and
-        parts[-1] == '/dev/null'):
-        command = ' '.join(parts[0:-2])
-        parts = command.split()
-        standardoutput='null';
-
-    if (len(parts) >= 2 and
-        parts[-1] == '>/dev/null'):
-        command = ' '.join(parts[0:-1])
-        parts = command.split()
-        standardoutput='null';
-
-    if (len(parts) == 6 and
-        parts[0] == '[' and
-        parts[1] in ['-x','-f','-e'] and
-        parts[2] == parts[5] and
-        parts[3] == ']' and
-        parts[4] == '&&' ):
-            testremoved = parts[2]
-            command = ' '.join(parts[5:])
+        if (len(parts) >= 3 and
+            parts[-2] == '>' and
+            parts[-1] == '/dev/null'):
+            command = ' '.join(parts[0:-2])
             parts = command.split()
+            standardoutput='null';
 
-    if (len(parts) == 5 and
-        parts[0] == 'test' and
-        parts[1] in ['-x','-f','-e'] and
-        parts[2] == parts[4] and
-        parts[3] == '&&' ):
-            testremoved = parts[2]
-            command = ' '.join(parts[4:])
+        if (len(parts) >= 2 and
+            parts[-1] == '>/dev/null'):
+            command = ' '.join(parts[0:-1])
             parts = command.split()
+            standardoutput='null';
 
-    if testremoved and not os.path.isfile(testremoved): return
+        if (len(parts) == 6 and
+            parts[0] == '[' and
+            parts[1] in ['-x','-f','-e'] and
+            parts[2] == parts[5] and
+            parts[3] == ']' and
+            parts[4] == '&&' ):
+                testremoved = parts[2]
+                command = ' '.join(parts[5:])
+                parts = command.split()
 
-    # TODO: translate  'command%line1%line2%line3
-    # in '/bin/echo -e line1\\nline2\\nline3 | command'
-    # to be POSIX compliant
+        if (len(parts) == 5 and
+            parts[0] == 'test' and
+            parts[1] in ['-x','-f','-e'] and
+            parts[2] == parts[4] and
+            parts[3] == '&&' ):
+                testremoved = parts[2]
+                command = ' '.join(parts[4:])
+                parts = command.split()
+
+        if testremoved and not os.path.isfile(testremoved): return
+
+        # TODO: translate  'command%line1%line2%line3
+        # in '/bin/echo -e line1\\nline2\\nline3 | command'
+        # to be POSIX compliant
 
     if not (len(parts) == 1 and os.path.isfile(command)):
         command=job['s'] + " -c '" + command + "'"


### PR DESCRIPTION
We cannot assume the shell language is always KSH compatible.
Perform a crude check by matching the shell binary against a known list.

This was one of my recommendations when implementing command manipulations, as I was guilty of using weird shells (including _gasp_ emacs) for a long time.
