### PR TITLE
Perform PATH home directory expansion.

### DIFF
--- a/src/bin/systemd-crontab-generator
+++ b/src/bin/systemd-crontab-generator
@@ -23,6 +23,18 @@ def files(dirname):
     except OSError:
         return []
 
+def expand_home_path(path, user):
+    try:
+        home = pwd.getpwnam(user).pw_dir
+    except KeyError:
+        return path
+
+    parts = path.split(':')
+    for i, part in enumerate(parts):
+        if part.startswith('~/'):
+            parts[i] = home + part[1:]
+    return ':'.join(parts)
+
 def parse_crontab(filename, withuser=True, monotonic=False):
     basename = os.path.basename(filename)
     environment = { }
@@ -46,8 +58,10 @@ def parse_crontab(filename, withuser=True, monotonic=False):
                      start_hours_range = value
                 elif envvar.group(1) == 'PERSISTENT':
                      persistent = {'true': True, 'yes': True, '1': True}.get(value.lower(), False)
+                elif not withuser and envvar.group(1) == 'PATH':
+                     environment['PATH'] = expand_home_path(value, basename)
                 else:
-                    environment[envvar.group(1)] = value
+                     environment[envvar.group(1)] = value
                 continue
 
             parts = line.split()


### PR DESCRIPTION
Expands ~/ components inside PATH, which is shell agnostic.

This is what I intended in my original proposal for home directory expansion, as this doesn't involve rewriting the command and is completely shell agnostic.

$SHELL -c 'command' will already perform home expansion on the _command_ (if supported by the shell). Performing ~ expansion in the command as well however doesn't hurt when the command isn't run through the shell -c flag.
