### PR TITLE
Emit stable unit IDs for persistent jobs

### DIFF
--- a/src/bin/systemd-crontab-generator
+++ b/src/bin/systemd-crontab-generator
@@ -5,6 +5,7 @@ import pwd
 import re
 import string
 from functools import reduce
+import hashlib
 
 envvar_re = re.compile(r'^([A-Za-z_0-9]+)\s*=\s*(.*)$')
 
@@ -198,9 +199,6 @@ def parse_period(mapping=int):
     return parser
 
 def generate_timer_unit(job, seq):
-    n = next(seq)
-    unit_name = "cron-%s-%s-%s" % (job['j'],job['u'], n)
-
     persistent = job['P']
 
     command=job['c']
@@ -335,6 +333,14 @@ def generate_timer_unit(job, seq):
          job['d'] == ['*'] and
          job['h'] == ['*']):
             persistent = False
+
+    if not persistent:
+        unit_id = next(seq)
+    else:
+        unit_id = hashlib.md5()
+        unit_id.update(bytes('\0'.join([schedule, command]), 'utf-8'))
+        unit_id = unit_id.hexdigest()
+    unit_name = "cron-%s-%s-%s" % (job['j'], job['u'], unit_id)
 
     with open('%s/%s.timer' % (TARGET_DIR, unit_name), 'w') as f:
         f.write('[Unit]\n')


### PR DESCRIPTION
Persistent job IDs are generated as a hash(schedule, command), so that
re-ordering of the command sequence (either in crontabs or due to filename
change) or a change in schedule with identical behavior doesn't clash on a
previously-existing unit ID.
