### PR TITLE
systemd rootprefix=/ fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -18,6 +18,7 @@ statedir	:= @statedir@
 mandir		:= @mandir@
 docdir		:= @docdir@
 unitdir		:= @unitdir@
+generatordir	:= @generatordir@
 
 runparts	:= @runparts@
 
@@ -88,7 +89,7 @@ test: all
 
 install: all
 	install -m755 -D $(builddir)/bin/crontab $(DESTDIR)$(bindir)/crontab
-	install -m755 -D $(builddir)/bin/systemd-crontab-generator $(DESTDIR)$(libdir)/systemd/system-generators/systemd-crontab-generator
+	install -m755 -D $(builddir)/bin/systemd-crontab-generator $(DESTDIR)$(generatordir)/systemd-crontab-generator
 	install -m755 -D $(builddir)/bin/remove_stale_stamps $(DESTDIR)$(libdir)/$(package)/remove_stale_stamps
 	install -m755 -D $(builddir)/bin/mail_on_failure $(DESTDIR)$(libdir)/$(package)/mail_on_failure
 	install -m755 -D $(builddir)/bin/boot_delay $(DESTDIR)$(libdir)/$(package)/boot_delay

--- a/configure
+++ b/configure
@@ -9,6 +9,7 @@ statedir='/var/spool/cron'
 mandir='$(datadir)/man'
 docdir='$(datadir)/doc/$(package)'
 unitdir='$(libdir)/systemd/system'
+generatordir='%(libdir)/systemd/system-generators'
 runparts='/usr/bin/run-parts'
 enable_setgid=no
 
@@ -40,6 +41,7 @@ statedir:,
 mandir:,
 docdir:,
 unitdir:,
+generatordir:,
 runparts:,
 enable-boot::,
 enable-minutely::,
@@ -107,6 +109,10 @@ do
 
         '--unitdir')
             unitdir="${2}"
+            shift 2;;
+
+        '--generatordir')
+            generatordir="${2}"
             shift 2;;
 
         '--runparts')
@@ -225,6 +231,7 @@ s|@statedir@|${statedir}|g
 s|@mandir@|${mandir}|g
 s|@docdir@|${docdir}|g
 s|@unitdir@|${unitdir}|g
+s|@generatordir@|${generatordir}|g
 s|@runparts@|${runparts}|g
 " Makefile.in >> Makefile
 

--- a/src/bin/systemd-crontab-generator.py
+++ b/src/bin/systemd-crontab-generator.py
@@ -558,7 +558,7 @@ def main():
 
             f.write('\n[Service]\n')
             f.write('Type=oneshot\n')
-            f.write('ExecStart=/bin/sh -c "@bindir@/systemctl daemon-reload ; @bindir@/systemctl try-restart cron.target"\n')
+            f.write('ExecStart=/bin/sh -c "systemctl daemon-reload ; systemctl try-restart cron.target"\n')
 
         MULTIUSER_DIR = os.path.join(TARGET_DIR, 'multi-user.target.wants')
 

--- a/src/units/cron-update.service.in
+++ b/src/units/cron-update.service.in
@@ -5,4 +5,4 @@ Documentation=man:systemd.cron(7)
 [Service]
 Type=oneshot
 ExecStartPre=/usr/bin/touch /run/crond.reboot
-ExecStart=/bin/sh -c '@bindir@/systemctl daemon-reload ; sleep 1 ; @bindir@/systemctl restart cron.target'
+ExecStart=/bin/sh -c 'systemctl daemon-reload ; sleep 1 ; systemctl restart cron.target'


### PR DESCRIPTION
A couple of changes to fix problems when systemd is installed in /, but systemd-cron is in /usr.

Fixes: https://github.com/systemd-cron/systemd-cron/issues/54