### PR TITLE
Escape '%' in unit description

### DIFF
--- a/src/bin/systemd-crontab-generator.py
+++ b/src/bin/systemd-crontab-generator.py
@@ -419,7 +419,7 @@ def generate_timer_unit(job, seq):
 
     with open('%s/%s.timer' % (TARGET_DIR, unit_name), 'w' , encoding='utf8') as f:
         f.write('[Unit]\n')
-        f.write('Description=[Timer] "%s"\n' % job['l'])
+        f.write('Description=[Timer] "%s"\n' % job['l'].replace('%', '%%'))
         f.write('Documentation=man:systemd-crontab-generator(8)\n')
         f.write('PartOf=cron.target\n')
         f.write('SourcePath=%s\n' % job['f'])
@@ -444,7 +444,7 @@ def generate_timer_unit(job, seq):
 
     with open('%s/%s.service' % (TARGET_DIR, unit_name), 'w', encoding='utf8') as f:
         f.write('[Unit]\n')
-        f.write('Description=[Cron] "%s"\n' % job['l'])
+        f.write('Description=[Cron] "%s"\n' % job['l'].replace('%', '%%'))
         f.write('Documentation=man:systemd-crontab-generator(8)\n')
         f.write('SourcePath=%s\n' % job['f'])
         if '"MAILTO="' in job['e']:


### PR DESCRIPTION
'%' has special meaning in systemd unit files. It has to be properly escaped to avoid errors.
Doing so by replacing '%' with '%%' in the description field.

The description field is populated with the cron command line by systemd-crontab-generator.py
and can therefore contain '%', like e.g. in Debian's mdadm cron command.