### PR TITLE
mail_on_failure: overhaul (needs Python 3.6+)

### DIFF
--- a/src/bin/mail_on_failure.py
+++ b/src/bin/mail_on_failure.py
@@ -1,65 +1,93 @@
 #!/usr/bin/python3
-import sys
+import argparse
+import email.mime.text
+import email.utils
+import logging
 import os
+import shlex
 import subprocess
-from subprocess import Popen, PIPE
 
-try:
-    job = sys.argv[1]
-except IndexError:
-    sys.exit("Usage: %s <unit>" % sys.argv[0])
 
-for pgm in ('/usr/sbin/sendmail', '/usr/lib/sendmail'):
-    if os.path.exists(pgm):
-        break
-else:
-    print("<3>can't send error mail for %s without a MTA" % job)
-    exit(0)
+__DOC__ = """ send a panic email about a failed cron job """
 
-user = subprocess.check_output(['systemctl','show',job,'--property=User'], universal_newlines=True)
+parser = argparse.ArgumentParser(description=__DOC__)
+parser.add_argument('unit', help='the failing unit, e.g. cron-foo-1.service')
+parser.add_argument('--verbose', action='store_true')
+args = parser.parse_args()
+if args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
+
+# NOTE: this used to check for /usr/lib/sendmail, but
+#       ConditionFileIsExecutable=/usr/sbin/sendmail
+#       in cron-failure@ meant that was unreachable.
+
+user = subprocess.check_output(
+    ['systemctl', 'show', args.unit, '--property=User'],
+    universal_newlines=True)
 user = user.rstrip('\n').split('=')[1]
-if not user: user = 'root'
-
+if not user:
+    user = 'root'
 mailto = user
 
-job_env = subprocess.check_output(['systemctl','show',job,'--property=Environment'], universal_newlines=True)
+job_env = subprocess.check_output(
+    ['systemctl', 'show', args.unit, '--property=Environment'],
+    universal_newlines=True)
 job_env = job_env.rstrip('\n').split('=', 1)[1]
 
+# FIXME: don't try to re-parse systemctl show's Environment=.
+#        shlex isn't 100% consistent with systemd.
+#        Get structured data from systemd.
+#        But how -- dbus? -o json?
+#        Probably adds a dependency on python3-systemd :-(
 if job_env:
-    for var in job_env.split(' '):
-        try:
-            key , value = var.split('=', 1)
-            if key == 'MAILTO': mailto = value
-        except ValueError:
-            pass
+    for pair in shlex.split(job_env):
+        if pair.startswith('MAILTO='):
+            mailto = pair[len('MAILTO='):]
 
-if not mailto: exit(0)
+if not mailto:
+    logging.info('This cron job (%s) opted out of email, therefore quitting', args.unit)
+    exit(0)
 
-hostname = os.uname()[1]
-
-body = "From: root (systemd-cron)\n"
-body += "To: " + mailto + "\n"
-body += "Subject: [" + hostname + "] job " + job  + " failed\n"
-body += "MIME-Version: 1.0\n"
-body += "Content-Type: text/plain; charset=UTF-8\n"
-body += "Content-Transfer-Encoding: 8bit\n"
-body += "Auto-Submitted: auto-generated\n"
-body += "\n"
+# FIXME: are any of these "better"?
+#          platform.uname().node
+#          socket.gethostname()
+#          socket.getfqdn()
+hostname = os.uname().nodename  # NOTE: requires Python 3.3+
 
 for locale in (None, 'C.UTF-8', 'C'):
     if locale:
+        # FIXME: pass a deep copy of os.environ to check_output,
+        #        instead of editing the version used for the rest of this process.
         os.environ['LC_ALL'] = locale
     try:
-        systemctl = subprocess.check_output(['systemctl', 'status', job], universal_newlines=True)
+        subprocess.check_output(
+            ['systemctl', 'status', args.unit, '--full'],
+            universal_newlines=True)
     except UnicodeDecodeError:
-        # current locale is broken, try again
+        logging.info('current locale (%s) is broken, try again', locale)
         pass
     except subprocess.CalledProcessError as e:
-        if e.returncode != 3:
+        if e.returncode != 3:   # FIXME: what is this magic number?
             raise
         else:
-            body += e.output
+            # Convert stdout into an email.
+            # FIXME: capture stderr also?
+            message_object = email.mime.text.MIMEText(_text=e.output)
             break
+    raise RuntimeError('systemctl status should have failed')
 
-p = Popen(['sendmail','-i','-B8BITMIME',mailto], stdin=PIPE)
-p.communicate(bytes(body, 'UTF-8'))
+
+message_object['Date'] = email.utils.formatdate()
+message_object['From'] = 'root (systemd-cron)'
+message_object['To'] = mailto
+message_object['Subject'] = f'[{hostname}] job {args.unit} failed'  # NOTE: requires Python 3.6+
+message_object['Auto-Submitted'] = 'auto-generated'  # https://datatracker.ietf.org/doc/html/rfc3834#section-5
+
+subprocess.run(
+        ['/usr/sbin/sendmail',  # for consistency with ConditionFileIsExecutable=
+         '-i',
+         '-B8BITMIME',
+         mailto],                 # recipient
+        check=True,               # like subprocess.check_call()
+        universal_newlines=False,  # os.environ['LC_ALL'] gets wrecked above
+        input=message_object.as_bytes())


### PR DESCRIPTION
I was mildly annoyed at the "python2-y" style of this script, so
I rewrote it.  I haven't had time to test it yet!

Sorry I didn't bother to make individual commits for these changes.

Passes flake8 --max-line-length=132.

In Debian right now,

    Debian  8 ships python 3.4  (jessie)
    Debian  9 ships python 3.5  (stretch)
    Debian 10 ships python 3.7  (buster)
    Debian 11 ships python 3.9  (bullseye)

See also

    https://en.wikipedia.org/wiki/History_of_Python#Table_of_versions

Individual changes:

 * use argparse instead of hand-parsing CLI args.
   Gives --help for free.
   Gives better error handling.
   Requires Python 3.2+

 * use mail.mime.text instead of hand-rolling MIME.
   Simplifies header management.

 * Set an explicit Date field.
   Usually someone else will fix this later, e.g.
   postfix always_add_missing_headers=yes.
   But doing it here does not hurt.
   Always uses UTC, so may prevent privacy leak (MTA's timezone).

 * use shlex.split instead of hand-splitting.
   Hopefully hardens Environment= parsing in unlikely edge cases?
   Still not great.

 * use run(input=) instead of Popen().communicate.
   Much easier to read.
   Requires Python 3.5+

 * Pass --full to systemctl show.
   Probably has no effect.

 * Use logging() instead of silent except/pass antipattern.

 * Check that "sendmail" didn't fail.

 * Check that "systemctl status" DID fail.

 * Don't check for /usr/lib/sendmail, since
   the systemd calling unit can't use it.