### PR TITLE
Fix MAILTO environment variable usage

### DIFF
--- a/src/bin/systemd-crontab-generator.py
+++ b/src/bin/systemd-crontab-generator.py
@@ -456,7 +456,7 @@ def generate_timer_unit(job, seq=None, unit_name=None):
         f.write('Description=[Cron] "%s"\n' % job['l'].replace('%', '%%'))
         f.write('Documentation=man:systemd-crontab-generator(8)\n')
         f.write('SourcePath=%s\n' % job['f'])
-        if 'MAILTO= ' in job['e']:
+        if re.search('MAILTO=(\s+|$)', job['e']):
             pass # mails explicitely disabled
         elif not HAS_SENDMAIL:
             pass # mails automaticaly disabled

--- a/src/bin/systemd-crontab-generator.py
+++ b/src/bin/systemd-crontab-generator.py
@@ -456,9 +456,9 @@ def generate_timer_unit(job, seq=None, unit_name=None):
         f.write('Description=[Cron] "%s"\n' % job['l'].replace('%', '%%'))
         f.write('Documentation=man:systemd-crontab-generator(8)\n')
         f.write('SourcePath=%s\n' % job['f'])
-        if 'MAILTO=' in job['e']:
+        if 'MAILTO= ' in job['e']:
             pass # mails explicitely disabled
-        elif not HAS_SENDMAIL and '"MAILTO=' not in job['e']:
+        elif not HAS_SENDMAIL:
             pass # mails automaticaly disabled
         else:
             f.write('OnFailure=cron-failure@%i.service\n')


### PR DESCRIPTION
Fixes #79.

Empty `MAILTO=` in crontab will cause mail to be disabled explicitly.