### PR TITLE
Correct mail not sent when MAILFROM is not set

### DIFF
--- a/src/bin/mail_on_failure.py
+++ b/src/bin/mail_on_failure.py
@@ -26,7 +26,9 @@ user = subprocess.check_output(
                      ['systemctl', 'show', args.unit, '--property=User'],
                      universal_newlines=True)
 user = user.rstrip('\n')
-user = user.split('=')[1] if user else 'root'
+user = user.split('=')[1]
+if not user:
+    user = 'root'
 
 mailto = user
 mailfrom = 'root'


### PR DESCRIPTION
cron-failure will not send emails if MAILFROM is not set.  However, the script was clearly intended to default to sending from root if this is not set.

This is due to the script parsing the User property of the failed cron service incorrectly.

If the cron service does not have a User property set (which is how the cron-*.service units are configured in systemd-cron), then systemctl returns "User=" as the property value.

The conditional assignment only checks that the string is not empty, BEFORE splitting it at the equal sign.  After the split the string ends up being empty and no default user is set.

The correction is to first parse the string, and THEN check to see if it is empty after parsing.


Signed-off-by: Richard Freeman <rich0@gentoo.org>