### PR TITLE
Restore old 8BITMIME behavior

### DIFF
--- a/src/bin/mail_on_failure.py
+++ b/src/bin/mail_on_failure.py
@@ -71,7 +71,13 @@ for locale in (None, 'C.UTF-8', 'C'):
             output = e.output
             break
 
-message_object = email.mime.text.MIMEText(_text=output)
+# Encode the message in 8-bit UTF-8
+# Virtually all modern MTAs are 8-bit clean and send each other 8-bit data
+# without checking each other's 8BITMIME flag.
+utf8_8bit = email.charset.Charset('utf-8')
+utf8_8bit.body_encoding = None
+
+message_object = email.mime.text.MIMEText(_text=output, _charset=utf8_8bit)
 message_object['Date'] = email.utils.formatdate()
 message_object['From'] = mailfrom + ' (systemd-cron)'
 message_object['To'] = mailto


### PR DESCRIPTION
closes #87

Test:

I dropped this patch into /etc/portage/patches/sys-process/systemd-cron-1.15.19-r1/base64-fix.patch on a Gentoo Linux box and reinstalled the source package. Then tested it live with this cron task:

```
#!/bin/zsh

echo ×

exit 1
```

Got this email 8-bit instead of BASE64 encoded:
```
Return-Path: <_cron-failure@sinky.one>
X-Original-To: root
Delivered-To: root@sinky.one
Received: by sinky.one (Postfix, from userid 997)
        id 3B50C164FFF; Fri, 10 Mar 2023 04:00:09 -0800 (PST)
Content-Type: text/plain; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: 8bit
Date: Fri, 10 Mar 2023 12:00:09 -0000
From: root@sinky.one (systemd-cron)
To: root@sinky.one
Subject: [blinky] job cron-hourly failed
Auto-Submitted: auto-generated
Message-Id: <20230310120009.3B50C164FFF@sinky.one>

× cron-hourly.service - systemd-cron hourly script service
     Loaded: loaded (/usr/lib/systemd/system/cron-hourly.service; static)
     Active: failed (Result: exit-code) since Fri 2023-03-10 04:00:09 PST; 87ms ago
       Docs: man:systemd.cron(7)
    Process: 246698 ExecStart=/bin/run-parts /etc/cron.hourly (code=exited, status=1/FAILURE)
   Main PID: 246698 (code=exited, status=1/FAILURE)

Mar 10 04:00:02 blinky systemd[1]: Starting cron-hourly.service...
Mar 10 04:00:02 blinky run-parts[246699]: ×
Mar 10 04:00:02 blinky run-parts[246698]: run-parts: /etc/cron.hourly/fail exited with return code 1
Mar 10 04:00:08 blinky run-parts[246701]: use SECRET_KEY from env
Mar 10 04:00:08 blinky run-parts[246701]: Skipping nextcloud scan for user deleted. No scan directory configured.
Mar 10 04:00:08 blinky run-parts[246701]: Starting nextcloud scan for user clement.
Mar 10 04:00:09 blinky systemd[1]: cron-hourly.service: Main process exited, code=exited, status=1/FAILURE
Mar 10 04:00:09 blinky systemd[1]: cron-hourly.service: Failed with result 'exit-code'.
Mar 10 04:00:09 blinky systemd[1]: Failed to start cron-hourly.service.
Mar 10 04:00:09 blinky systemd[1]: cron-hourly.service: Triggering OnFailure= dependencies.
```