### PR TITLE
Fix expansion of commands starting with '~/'

### DIFF
--- a/src/bin/systemd-crontab-generator.py
+++ b/src/bin/systemd-crontab-generator.py
@@ -276,7 +276,7 @@ class Job:
             pass
         if self.home:
             if self.command[0].startswith('~/'):
-                self.command[0] = self.home + self.command[0][2:]
+                self.command[0] = self.home + self.command[0][1:]
 
             if 'PATH' in self.environment:
                 parts = self.environment['PATH'].split(':')


### PR DESCRIPTION
We need to replace the '~' with home but keep '/' and everything afterwards, i.e. slice [1:] from the command.  This was recently changed to take slice [2:], losing the '/'.

Fixes: 9ef7b89523e8 ("keep job.command as a List[str] all along")