### PR TITLE
Auto-enable all the schedules, we require systemd 236 now

### DIFF
--- a/configure
+++ b/configure
@@ -12,24 +12,17 @@ unitdir='$(libdir)/systemd/system'
 generatordir='$(libdir)/systemd/system-generators'
 enable_runparts=yes
 enable_setgid=no
+use_loglevelmax=no
 
-# systemd ≥ 197
 enable_boot=yes
 enable_hourly=yes
 enable_daily=yes
 enable_weekly=yes
 enable_monthly=yes
-
-# systemd ≥ 209
-enable_yearly=no
-
-# systemd ≥ 217
-enable_minutely=no
-enable_quarterly=no
-enable_semi_annually=no
-
-# systemd ≥ 236
-use_loglevelmax=no
+enable_yearly=yes
+enable_minutely=yes
+enable_quarterly=yes
+enable_semi_annually=yes
 
 ARGS=$(getopt -n "$(basename "${0}")" -o '' -l '
 prefix:,


### PR DESCRIPTION
Currently d/rules says
```
--enable-runparts=no \
--enable-boot=no \
--enable-setgid=yes \
--enable-yearly=yes \
--enable-persistent=yes
```
but even *bookworm* systemd supports everything, since it's 252.12-1~deb12u1: the minimum in the README is 236, default them all to on.