### PR TITLE
Add --with-{part,crond}2timer= instead of vendoring a superset of the debian configuration

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,11 +5,13 @@ CRONTAB ?= crontab
 
 version		:= $(file < VERSION)
 
-schedules			:= @schedules@
-schedules_not			:= @schedules_not@
+schedules		:= @schedules@
+schedules_not		:= @schedules_not@
 enable_runparts		:= @enable_runparts@
 enable_setgid		:= @enable_setgid@
 use_loglevelmax		:= @use_loglevelmax@
+part2timer		:= @part2timer@
+crond2timer		:= @crond2timer@
 
 prefix		:= @prefix@
 bindir		:= @bindir@
@@ -186,6 +188,11 @@ endif
 	sed -i $(foreach sched,$(schedules)    ,-e '1i.nr etccron_$(sched) 1') $@
 	sed -i $(foreach sched,$(schedules_not),-e '1i.nr etccron_$(sched) 0') $@
 
+$(builddir)/include/part2timer.hpp : $(part2timer) Makefile
+	 sort $< | sed '/^#/d;/^$$/d;s/^/{"/;s/	/"sv, "/;s/$$/"sv},/' > $@
+$(builddir)/include/crond2timer.hpp : $(crond2timer) Makefile
+	 sort $< | sed '/^#/d;/^$$/d;s/^/{"/;s/	/"sv, "/;s/$$/"sv},/' > $@
+
 $(builddir)/include/configuration.hpp : $(srcdir)/include/configuration.hpp.in Makefile
 	sed -e 's:\@use_loglevelmax\@:$(use_loglevelmax):' \
 	    -e 's:\@use_runparts\@:$(use_runparts):' \
@@ -207,7 +214,7 @@ common_headers := $(builddir)/include/configuration.hpp $(builddir)/include/libv
 $(builddir)/include/libvoreutils.hpp.gch : $(builddir)/include/libvoreutils.hpp
 	$(CXX) -Wall -Wextra -fno-exceptions $(CFLAGS) $(CPPFLAGS) -std=c++20 -I $(builddir)/include            $< -o $@
 
-$(builddir)/bin/systemd-crontab-generator: $(srcdir)/bin/systemd-crontab-generator.cpp $(common_headers)
+$(builddir)/bin/systemd-crontab-generator: $(srcdir)/bin/systemd-crontab-generator.cpp $(common_headers) $(builddir)/include/part2timer.hpp $(builddir)/include/crond2timer.hpp
 	$(CXX) -Wall -Wextra -fno-exceptions $(CFLAGS) $(CPPFLAGS) -std=c++20 -I $(builddir)/include $(PCH_ARG) $< -o $@ $(LDFLAGS) @libcrypto@
 
 $(builddir)/bin/crontab: $(srcdir)/bin/crontab.cpp $(common_headers)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Other options include:
   Default: `no`.
 * `--libcrypto=<flags>` Compiler and linker flags required to build and link to libcrypto.
   Default: `pkgconf --cflags --libs libcrypto` or `-lcrypto`.
+* `--with-part2timer=file` Mapping from basename in /etc/cron.{daily,weekly,etc.) to unit name.
+  Default: `/dev/null`.
+* `--with-crond2timer=file` Mapping from basename in /etc/cron.d to unit name.
+  Default: `/dev/null`.
 
 A typical configuration for the latest systemd would be:
 
@@ -117,6 +121,16 @@ Alternatively you can also generate individual .timer/.service for all the jobs
 in /etc/cron.{hourly,daily,weekly,monthly,...}:
 
     $ ./configure --enable-runparts=no
+
+
+`part2timer` and `crond2timer` are in the format
+
+    basename<tab>unitbasename
+
+(empty lines and start-of-line `#`-comments permitted; unitbasename doesn't include ".timer") and may be useful when, for example,
+`/etc/cron.daily/plocate` has a timer called `plocate-updatedb.timer` or `/etc/cron.d/ntpsec` has a timer called `ntpsec-rotate-stats.timer`:
+without the override, the jobs would run twice since native-timer detection would be looking for `plocate.timer` and `ntpsec.timer`.
+
 
 ### Caveat
 

--- a/configure
+++ b/configure
@@ -14,6 +14,9 @@ libcrypto="$(pkgconf --cflags --libs libcrypto)" 2>/dev/null || libcrypto='-lcry
 enable_runparts=yes
 enable_setgid=no
 use_loglevelmax=no
+part2timer=/dev/null
+crond2timer=/dev/null
+
 
 enable_boot=yes
 enable_minutely=no
@@ -51,6 +54,8 @@ enable-yearly::,
 enable-setgid::,
 enable-runparts::,
 use-loglevelmax::,
+with-part2timer:,
+with-crond2timer:,
 ' -- "${@}")
 
 if [ $? -ne 0 ]; then
@@ -173,6 +178,14 @@ do
             esac
             shift 2;;
 
+        '--with-part2timer')
+            part2timer="${2}"
+            shift 2;;
+
+        '--with-crond2timer')
+            crond2timer="${2}"
+            shift 2;;
+
         '--')
             shift
             break;;
@@ -217,4 +230,6 @@ s|@unitdir@|${unitdir}|g
 s|@generatordir@|${generatordir}|g
 s|@libcrypto@|${libcrypto}|g
 s|@use_loglevelmax@|${use_loglevelmax}|g
+s|@part2timer@|${part2timer}|g
+s|@crond2timer@|${crond2timer}|g
 " Makefile.in > Makefile

--- a/src/bin/systemd-crontab-generator.cpp
+++ b/src/bin/systemd-crontab-generator.cpp
@@ -37,18 +37,16 @@ static const constexpr std::string_view VALID_CHARS = "-"
                                                       "abcdefghijklmnopqrstuvwxyz"sv;  // keep sorted
 
 
-// this is dumb, but gets the job done
 static const constexpr std::pair<std::string_view, std::string_view> PART2TIMER[] = {
-    {"apt-compat"sv, "apt-daily"sv},
-    {"dpkg"sv, "dpkg-db-backup"sv},
-    {"plocate"sv, "plocate-updatedb"sv},
-    {"sysstat"sv, "sysstat-summary"sv},
+    // kept sorted by Makefile
+#include "part2timer.hpp"
+    {"\xFF"sv, ""sv},  // we can't have an empty array (if no mapping set), so this sorts after everything
 };
 
 static const constexpr std::pair<std::string_view, std::string_view> CROND2TIMER[] = {
-    {"ntpsec"sv, "ntpsec-rotate-stats"sv},
-    {"ntpsec-ntpviz"sv, "ntpviz-daily"sv},
-    {"sysstat"sv, "sysstat-collect"sv},
+    // kept sorted by Makefile
+#include "crond2timer.hpp"
+    {"\xFF"sv, ""sv},  // we can't have an empty array (if no mapping set), so this sorts after everything
 };
 
 static auto which(const std::string_view & exe, std::optional<std::string_view> paths = {}) -> std::optional<std::string> {


### PR DESCRIPTION
The current configuration is
```
apt-compat	apt-daily
dpkg	dpkg-db-backup
plocate	plocate-updatedb
sysstat	sysstat-summary
```
and
```
ntpsec	ntpsec-rotate-stats
ntpsec-ntpviz	ntpviz-daily
sysstat	sysstat-collect
```
(but debian doesn't ship some of these, so trim as appropriate).