### PR TITLE
Accept TZ in environment as OnCalendar= timezone (only if systemd will accept it)

### DIFF
--- a/src/man/crontab.5.in
+++ b/src/man/crontab.5.in
@@ -139,6 +139,15 @@ only recognize @ keywords to be persistent
 force all further jobs not to be persistent
 
 .TP
+.B TZ
+The job is scheduled in this time-zone instead of in the system time-zone.
+Must be a full IANA time-zone name
+(as found under
+.IR /usr/share/zoneinfo ),
+otherwise no special semantics.
+Always passed to the job.
+
+.TP
 .B BATCH
 This boolean flag is translated to options
 .B CPUSchedulingPolicy=idle

--- a/test/test-generator
+++ b/test/test-generator
@@ -24,24 +24,31 @@ assert_dat() {  # file content testname
 {
 	echo 'dummy:x:12:34:dummy:/home/dummy:/bin/sh' > /etc/passwd
 
-	printf '%s\n' '# test_path_expansion, test_period_basic'        \
-	              '@daily dummy true'                               \
-	                                                                \
-	              '# test_userpath_expansion'                       \
-	              '@daily dummy ~/fake'                             \
-	                                                                \
-	              '# test_timespec_basic'                           \
-	              '5 6 * * * dummy true'                            \
-	                                                                \
-	              '# test_timespec_slice'                           \
-	              '*/5 * * * * dummy true'                          \
-	                                                                \
-	              '# test_timespec_range'                           \
-	              '1 * * * mon-wed dummy true'                      \
-	                                                                \
-	              '# test_substitutions'                            \
-	              '1 * * * mon-wed dummy echo dev null > /dev/null' \
-	              '1 * * * mon-wed dummy echo devnull  >/dev/null'  > /etc/crontab
+	printf '%s\n' '# test_path_expansion, test_period_basic'                  \
+	              '@daily dummy true'                                         \
+	                                                                          \
+	              '# test_userpath_expansion'                                 \
+	              '@daily dummy ~/fake'                                       \
+	                                                                          \
+	              '# test_timespec_basic'                                     \
+	              '5 6 * * * dummy true'                                      \
+	                                                                          \
+	              '# test_timespec_slice'                                     \
+	              '*/5 * * * * dummy true'                                    \
+	                                                                          \
+	              '# test_timespec_range'                                     \
+	              '1 * * * mon-wed dummy true'                                \
+	                                                                          \
+	              '# test_substitutions'                                      \
+	              '1 * * * mon-wed dummy echo dev null > /dev/null'           \
+	              '1 * * * mon-wed dummy echo devnull  >/dev/null'            \
+	                                                                          \
+	              '# test_tz'                                                 \
+	              'TZ=Europe/Warsaw'                                          \
+	              '1 * * * mon-wed dummy echo in zoneinfo'                    \
+	              'TZ=UTC0'                                                   \
+	              '1 * * * mon-wed dummy echo valid $TZ, but not in zoneinfo' \
+	              'TZ='                                                       > /etc/crontab
 
 	"$S_C_G" /etc/out
 	cd /etc/out || exit
@@ -58,6 +65,9 @@ assert_dat() {  # file content testname
 
 	assert_dat cron-crontab-dummy-3.sh      '/usr/bin/echo dev null' test_substitutions
 	assert_dat cron-crontab-dummy-4.sh      '/usr/bin/echo devnull'  test_substitutions
+
+	assert_key cron-crontab-dummy-5.timer   'OnCalendar' 'Mon,Tue,Wed *-*-* *:1:00 Europe/Warsaw'       test_tz  # systemd accepts zones it finds in the zoneinfo file, but only by exact match
+	assert_key cron-crontab-dummy-6.timer   'OnCalendar' 'Mon,Tue,Wed *-*-* *:1:00'                     test_tz  # TZ=UTC0 is valid (as is TZ=UTC2), but systemd doesn't accept it as a suffix
 }
 
 


### PR DESCRIPTION
We can't just paste it at the end without validation, since systemd will error for invalid "timezones" at the end.

Unfortunately "invalid" also means "TZ=UTC0 is forbidden", but that also makes validation trivial.