### PR TITLE
Fix Makefile when all schedules are enabled

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -184,9 +184,16 @@ ifneq ($(enable_runparts),yes)
 else
 	sed -i $(foreach sched,$(schedules)    ,-e '1i.nr timer_$(sched) 1') $@
 endif
+
+ifneq ($(schedules_not),)
 	sed -i $(foreach sched,$(schedules_not),-e '1i.nr timer_$(sched) 0') $@
+endif
+
 	sed -i $(foreach sched,$(schedules)    ,-e '1i.nr etccron_$(sched) 1') $@
+
+ifneq ($(schedules_not),)
 	sed -i $(foreach sched,$(schedules_not),-e '1i.nr etccron_$(sched) 0') $@
+endif
 
 $(builddir)/include/part2timer.hpp : $(part2timer)
 	sort $< | awk '/^#/ || /^$$/ {next}  { print "{\"" $$1 "\"sv, \"" $$2 "\"sv}," }' > $@


### PR DESCRIPTION
If all schedules are enabled by using the configure flags: `--enable-minutely`, `--enable-quarterly`, and `--enable-semi_annually` to enable the ones that are disabled by default, then `make` will fail with the following error:

```
sed -i  /PROJECT_ROOT/out/build/man/systemd.cron.7
sed: -e expression #1, char 8: extra characters after command
make: *** [Makefile:184: /PROJECT_ROOT/out/build/man/systemd.cron.7] Error 1
```

This is due to the `$(schedules_not)` variable's being empty and thus no `-e` expression flags are generated for the `sed` command.

This commit fixes this by adding conditional guards around the usage of `$(schedules_not)` so those commands are only invoked when it is not empty.

Similar bugs may still exist; I've only fixed what I've encountered.