### PR TITLE
m_f_j: more useful mail subjects

### DIFF
--- a/test/m_f_j/bothMAIL.output
+++ b/test/m_f_j/bothMAIL.output
@@ -5,10 +5,11 @@ Content-Transfer-Encoding: binary
 Date: Fri, 01 Dec 2000 23:00:00 +0000
 From: henry@zbysiopatia.jpeg (systemd-cron)
 To: chlupsko@henry.jpeg
-Subject: [tarta] job bothMAIL.service failed
+Subject: [tarta] Failure: m_f_j/bothMAIL
 X-Mailer: systemd-cron @VERSION@
 Auto-Submitted: auto-generated
 
 User=
 Environment="PATH=żupan:/etc" MAILFROM=henry@zbysiopatia.jpeg TZ=UTC0 MAILTO=chlupsko@henry.jpeg
 ActiveState=failed
+SourcePath=m_f_j/bothMAIL

--- a/test/m_f_j/bothMAIL.service
+++ b/test/m_f_j/bothMAIL.service
@@ -1,3 +1,4 @@
 User=
 Environment="PATH=żupan:/etc" MAILFROM=henry@zbysiopatia.jpeg TZ=UTC0 MAILTO=chlupsko@henry.jpeg
 ActiveState=failed
+SourcePath=m_f_j/bothMAIL

--- a/test/m_f_j/noconfig.output
+++ b/test/m_f_j/noconfig.output
@@ -5,7 +5,7 @@ Content-Transfer-Encoding: binary
 Date: Fri, 01 Dec 2000 23:00:00 +0000
 From: root (systemd-cron)
 To: root
-Subject: [tarta] job noconfig.service failed
+Subject: [tarta] Failure: noconfig.service
 X-Mailer: systemd-cron @VERSION@
 Auto-Submitted: auto-generated
 

--- a/test/m_f_j/ok.output
+++ b/test/m_f_j/ok.output
@@ -5,7 +5,7 @@ Content-Transfer-Encoding: binary
 Date: Fri, 01 Dec 2000 23:00:00 +0000
 From: root (systemd-cron)
 To: root
-Subject: [tarta] job ok.service output
+Subject: [tarta] Output: ok.service
 X-Mailer: systemd-cron @VERSION@
 Auto-Submitted: auto-generated
 

--- a/test/m_f_j/user.output
+++ b/test/m_f_j/user.output
@@ -5,7 +5,7 @@ Content-Transfer-Encoding: binary
 Date: Fri, 01 Dec 2000 23:00:00 +0000
 From: root (systemd-cron)
 To: henry
-Subject: [tarta] job user.service failed
+Subject: [tarta] Failure: user.service
 X-Mailer: systemd-cron @VERSION@
 Auto-Submitted: auto-generated
 

--- a/test/test-generator
+++ b/test/test-generator
@@ -13,11 +13,11 @@ if [ -d "$STATEDIR" ]; then
 	mount -t tmpfs tmpfs "$STATEDIR" || exit
 fi
 command -v /usr/sbin/sendmail /usr/lib/sendmail > /dev/null || {
-	# s-c-g won't generate mail units if it doesn't have sendmail in one of these two locations: provide a fake one in this case
+	# s-c-g won't generate On{Success,Failure}= lines if it doesn't have sendmail in one of these two locations: provide a fake one in this case
 	mkdir -p /etc/sbin/sbin /etc/sbin/up /etc/sbin/work
 	ln -s /bin/true /etc/sbin/up/sendmail
 	mount --bind /usr/sbin /etc/sbin/sbin
-	mount -t overlay overlay -o 'lowerdir=/etc/sbin/sbin,upperdir=/etc/sbin/up,workdir=/etc/sbin/work' /usr/sbin
+	mount -t overlay -o 'lowerdir=/etc/sbin/sbin,upperdir=/etc/sbin/up,workdir=/etc/sbin/work' overlay /usr/sbin
 }
 
 


### PR DESCRIPTION
Per https://github.com/systemd-cron/systemd-cron/issues/120#issuecomment-1712528145:

```
   1     01:00 systemd-cron    (  14) [tarta] /etc/crontab line 22: failure
   2     00:51 systemd-cron    (4.2K) [tarta] /etc/cron.weekly/dnsmasq-update-adblock-hosts: output
   3   + 00:51 systemd-cron    (2.7K) [tarta] nabijaczleweli's crontab line 2: output
```
(.daily &c. jobs don't have a line number, naturally, crontab ones get one. users' crontabs are pre-parsed as "<file's basename>'s crontab" instead, since the path is horrific)

with
```
Date: Sun, 10 Sep 2023 01:00:00 +0200
From: systemd-cron <root@tarta.nabijaczleweli.xyz>
To: root@tarta.nabijaczleweli.xyz
Subject: [tarta] /etc/crontab line 22: failed
X-Mailer: systemd-cron 2.1.1+testupa-1

× cron-crontab-root-0.service - [Cron] "0 *     * * *   root    echo dupaninka; false"
     Loaded: loaded (/etc/crontab; generated)
     Active: failed (Result: exit-code) since Sun 2023-09-10 01:00:00 CEST; 48ms ago
TriggeredBy: ● cron-crontab-root-0.timer
       Docs: man:systemd-crontab-generator(8)
    Process: 1743692 ExecStart=/bin/sh /run/systemd/generator/cron-crontab-root-0.sh (code=exited, status=1/FAILURE)
   Main PID: 1743692 (code=exited, status=1/FAILURE)
        CPU: 3ms
2023-09-10T01:00:00+0200 tarta systemd[1]: Starting cron-crontab-root-0.service - [Cron] "0 *        * * *        root        echo dupaninka; false"...
2023-09-10T01:00:00+0200 tarta sh[1743914]: dupaninka
2023-09-10T01:00:00+0200 tarta systemd[1]: cron-crontab-root-0.service: Main process exited, code=exited, status=1/FAILURE
2023-09-10T01:00:00+0200 tarta systemd[1]: cron-crontab-root-0.service: Failed with result 'exit-code'.
2023-09-10T01:00:00+0200 tarta systemd[1]: Failed to start cron-crontab-root-0.service - [Cron] "0 *        * * *        root        echo dupaninka; false".
2023-09-10T01:00:00+0200 tarta systemd[1]: cron-crontab-root-0.service: Triggering OnFailure= dependencies.
```

```
Date: Sun, 10 Sep 2023 00:51:37 +0200
From: systemd-cron <root@tarta.nabijaczleweli.xyz>
To: root@tarta.nabijaczleweli.xyz
Subject: [tarta] /etc/cron.weekly/dnsmasq-update-adblock-hosts: output
X-Mailer: systemd-cron 2.1.1+testupa-1

○ cron-weekly-dnsmasq-update-adblock-hosts.service - [Cron] /etc/cron.weekly/dnsmasq-update-adblock-hosts
     Loaded: loaded (/etc/cron.weekly/dnsmasq-update-adblock-hosts; generated)
     Active: inactive (dead) since Sun 2023-09-10 00:51:36 CEST; 216ms ago
TriggeredBy: ● cron-weekly-dnsmasq-update-adblock-hosts.timer
       Docs: man:systemd-crontab-generator(8)
    Process: 3907001 ExecStart=/etc/cron.weekly/dnsmasq-update-adblock-hosts (code=exited, status=0/SUCCESS)
   Main PID: 3907001 (code=exited, status=0/SUCCESS)
        CPU: 1.068s
2023-09-10T00:51:31+0200 tarta systemd[1]: Starting cron-weekly-dnsmasq-update-adblock-hosts.service - [Cron] /etc/cron.weekly/dnsmasq-update-adblock-hosts...
2023-09-10T00:51:31+0200 tarta dnsmasq-update-adblock-hosts[3907025]: Downloading https://zerodot1.gitlab.io/CoinBlockerLists/hosts_browser
2023-09-10T00:51:31+0200 tarta dnsmasq-update-adblock-hosts[3907025]: Downloading https://raw.githubusercontent.com/mitchellkrogza/Badd-Boyz-Hosts/master/hosts
...
```

```
Date: Sun, 10 Sep 2023 00:51:33 +0200
From: systemd-cron <root@tarta.nabijaczleweli.xyz>
To: nabijaczleweli@tarta.nabijaczleweli.xyz
Subject: [tarta] nabijaczleweli's crontab line 2: output
X-Mailer: systemd-cron 2.1.1+testupa-1

○ cron-nabijaczleweli-nabijaczleweli-0.service - [Cron] "0   *    *   *     *   PATH=$HOME/bin:$HOME/.cargo/bin:$PATH; exec update-feeds ~/.feeds"
     Loaded: loaded (/var/spool/cron/crontabs/nabijaczleweli; generated)
     Active: inactive (dead) since Sun 2023-09-10 00:51:32 CEST; 458ms ago
TriggeredBy: ● cron-nabijaczleweli-nabijaczleweli-0.timer
       Docs: man:systemd-crontab-generator(8)
    Process: 3906894 ExecStart=/bin/sh /run/systemd/generator/cron-nabijaczleweli-nabijaczleweli-0.sh (code=exited, status=0/SUCCESS)
   Main PID: 3906894 (code=exited, status=0/SUCCESS)
        CPU: 6.990s
2023-09-10T00:51:31+0200 tarta systemd[1]: Starting cron-nabijaczleweli-nabijaczleweli-0.service - [Cron] "0   *    *   *     *   PATH=$HOME/bin:$HOME/.cargo/bin:$PATH; exec update-feeds ~/.feeds"...
2023-09-10T00:51:31+0200 tarta sh[3907022]: curl: (6) Could not resolve host: blog.q3w3e3.dev
2023-09-10T00:51:31+0200 tarta sh[3907164]: Reading /run/user/1000/feeds/just-between-us.feed failed: unable to parse feed: no root element
2023-09-10T00:51:31+0200 tarta sh[3907173]: Reading /run/user/1000/feeds/gossip.feed failed: unable to parse feed: no root element
...
```