### PR TITLE
Settle on a colour scheme for crontab -l

### DIFF
--- a/src/bin/systemd-crontab-generator.cpp
+++ b/src/bin/systemd-crontab-generator.cpp
@@ -8,13 +8,6 @@ static const constexpr auto key_or_plain = [](auto && lhs, auto && rhs) {
 };
 
 
-static const regex_t ENVVAR_RE = [] {
-	regex_t ret;
-	assert(!regcomp(&ret, R"regex(^([A-Za-z_0-9]+)[[:space:]]*=[[:space:]]*(.*)$)regex", REG_EXTENDED | REG_NEWLINE));
-	assert(ret.re_nsub == 2);
-	return ret;
-}();
-
 static const constexpr std::uint8_t MINUTES_SET[]  = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                                       20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
                                                       40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59};

--- a/src/include/libvoreutils.hpp
+++ b/src/include/libvoreutils.hpp
@@ -329,6 +329,7 @@ namespace vore {
 			constexpr bool operator!=(const soft_tokenise_iter & rhs) const noexcept { return !(*this == rhs); }
 
 			constexpr std::string_view operator*() const noexcept { return this->token; }
+			constexpr const std::string_view * operator->() const noexcept { return &this->token; }
 		};
 
 

--- a/src/include/util.hpp
+++ b/src/include/util.hpp
@@ -24,3 +24,11 @@ static auto getpass_getlogin() -> std::string_view {
 
 	return {};
 }
+
+
+static const regex_t ENVVAR_RE = [] {
+	regex_t ret;
+	assert(!regcomp(&ret, R"regex(^([A-Za-z_0-9]+)[[:space:]]*=[[:space:]]*(.*)$)regex", REG_EXTENDED | REG_NEWLINE));
+	assert(ret.re_nsub == 2);
+	return ret;
+}();


### PR DESCRIPTION
Quoting the comment:
```
// Divide the crontab into three colour-coded sexions:
//   blue    for comments        (metadata for the user)
//   green   for time specs      (metadata for cron)
//   default for everything else (actual data)
```

This, I think, achieves a good semantic separation, which is what you want, without becoming complete neon soup (like some modernist hypermaximalist highlighters that end up being worse than `| cat`):
![](https://github.com/systemd-cron/systemd-cron/assets/6709544/6cdc06af-dd33-4199-8919-1c4156b4e02e)