### PR TITLE
helpful errors

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -208,7 +208,7 @@ $(builddir)/include/%.hpp: $(srcdir)/include/%.hpp
 CXXVER := $(shell $(CXX) --version | { read -r l; echo "$$l"; })
 ifneq "$(findstring clang,$(CXXVER))" ""
 	# clang doesn't use PCHs automatically
-	PCH_ARG := -include-pch $(builddir)/include/libvoreutils.hpp.gch
+	PCH_ARG := -include-pch $(builddir)/include/libvoreutils.hpp.gch -Wno-gcc-compat
 else
 	PCH_ARG :=
 endif


### PR DESCRIPTION
samples from crontab -t:
```
crontab: -: 1 2 0 1,12,27 sat,11 test: field day=0 (0), must be * or [1, 31]
crontab: -: 1 2 0 1,12,27 sat,11 test: field dow=sat,11 (11), must be * or [mon, sun] or [1, 7]
crontab: -: 1 2 0 1,12,27 sat,11 test: field month=1,12,27 (27), must be * or [jan, dec] or [1, 12]

crontab: -: 1 2 0-1- 1,12,27 sat,11 test: field day=0-1- (0-1-): doubled -

crontab: -: 1 2 99/1,w 1,12,27 sat,11 test: field day=99/1,w (99), may be * or [1, 31]
```

This also required fixing the log format to the usual `$0: file: line: message` from the weird out-of-order one

Closes #132