### PR TITLE
Parse a job's SENDMAIL in mail_for_job, use systemd's SENDMAIL therein as well. Add contrib/sendmail-matrix and -apprise

### DIFF
--- a/contrib/sendmail-apprise
+++ b/contrib/sendmail-apprise
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+from=
+subject=
+while read -r header rest; do
+	case "$header" in
+		""      )	break           ;;
+		From:   )	from="$rest"    ;;
+		Subject:)	subject="$rest" ;;
+	esac
+done
+
+exec apprise -vv -t "$subject – $from" -b "$(cat)"

--- a/contrib/sendmail-matrix
+++ b/contrib/sendmail-matrix
@@ -1,0 +1,25 @@
+#!/bin/sh
+TOKEN=systemd-cron  # probably source this from a file only readable by user _cron-failure, and don't make it "systemd-cron"
+# The TO stanza should look something like
+# TO='!QQQQQqqQQqQQqqQQqq:qqqqqqqqqqqqqq.qqq@https://matrix.qqqqqqqqqqqqqq.qqq:8448'
+
+
+from=
+to=
+subject=
+while read -r header rest; do
+	case "$header" in
+		""      )	break           ;;
+		From:   )	from="$rest"    ;;
+		To:     )	to="$rest"      ;;
+		Subject:)	subject="$rest" ;;
+	esac
+done
+
+room="${to%@*}"
+server="${to#*@}"
+
+
+content="$(jq -Rs --arg from "$from" --arg subject "$subject" '$subject + " ‒ " + $from + "\n\n" + .')"
+exec curl --fail-with-body --no-progress-meter --oauth2-bearer "$TOKEN" \
+	--data-binary '{"msgtype": "m.text", "body": '"$content"'}' -XPUT "$server/_matrix/client/r0/rooms/$room/send/m.room.message/$$"

--- a/src/bin/mail_for_job.sh
+++ b/src/bin/mail_for_job.sh
@@ -51,10 +51,12 @@ systemctl show --property=User --property=Environment --property=SourcePath --pr
 	mailto="$user"
 	mailfrom='root'
 
+	sendmail="$SENDMAIL"
 	for kv in $job_env; do
 		case "$kv" in
 			'MAILTO='*  )	mailto="${kv#'MAILTO='}"     ;;
 			'MAILFROM='*)	mailfrom="${kv#'MAILFROM='}" ;;
+			'SENDMAIL='*)	sendmail="${kv#'SENDMAIL='}" ;;
 		esac
 	done
 
@@ -102,5 +104,5 @@ systemctl show --property=User --property=Environment --property=SourcePath --pr
 		else
 			journalctl -u "$unit" -o cat       _SYSTEMD_INVOCATION_ID="$invocation_id"   SYSLOG_FACILITY=9
 		fi
-	} 2>&1 | "$SENDMAIL" -i -B 8BITMIME "$mailto"
+	} 2>&1 | "$sendmail" -i -B 8BITMIME "$mailto"
 }

--- a/src/man/systemd.cron.7.in
+++ b/src/man/systemd.cron.7.in
@@ -121,7 +121,12 @@ to view the output of scripts run from these units.
 . \}
 .
 .It Nm cron-mail@.service
-Sends mail in case a cron service unit fails, succeeds, or succeeds-but-only-if-it-wrote-something.
+Sends mail
+(via
+.Xr sendmail 1 ,
+which can be overridden with
+.Pf $ Ev SENDMAIL )
+in case a cron service unit fails, succeeds, or succeeds-but-only-if-it-wrote-something.
 The instance name
 .Pq the bit after the Sy @
 is the unit name,

--- a/src/units/cron-mail@.service.in
+++ b/src/units/cron-mail@.service.in
@@ -6,6 +6,7 @@ RefuseManualStop=true
 
 [Service]
 Type=oneshot
+PassEnvironment=SENDMAIL
 ExecStart=@libexecdir@/systemd-cron/mail_for_job %i
 User=_cron-failure
 Group=systemd-journal


### PR DESCRIPTION
sendmail-matrix result:
![](https://user-images.githubusercontent.com/6709544/275339062-67f77f64-79e6-46e8-a702-6aaab85bd1d7.png)

@a-detiste if you have an apprise config, can you please try running `SENDMAIL=contrib/sendmail-apprise out/build/bin/mail_for_job cron-ratrun-root-0.service:Failure` to test this (substitute the service name, of course)?

We could just ship sendmail-apprise in `/usr/share/doc/systemd-cron` or an equally conspicuous place and then it can work "out of the box".