### PR TITLE
Clarify why files with masked units are ignored

### DIFF
--- a/src/bin/systemd-crontab-generator.cpp
+++ b/src/bin/systemd-crontab-generator.cpp
@@ -1251,10 +1251,11 @@ static auto is_masked(const char * path, std::string_view name, vore::span<const
 
 		if(!access(unit_file.c_str(), F_OK)) {
 			const char * reason = "native timer is present";
+			const char * interjection = "";
 			struct stat sb;
 			if(!stat(unit_file.c_str(), &sb) && sb.st_size == 0)
-				reason = "it is masked";
-			log(Log::NOTICE, "ignoring %s/%.*s because %s", path, FORMAT_SV(name), reason);
+				interjection = " and masked";
+			log(Log::NOTICE, "ignoring %s/%.*s because it is overridden%s by native .timer unit", path, FORMAT_SV(name), interjection);
 			return true;
 		}
 	}


### PR DESCRIPTION
The previous message expanded to something like "ignoring &lt;file&gt; because it is masked".

Clarify that "it" refers to the unit, not the file.  Also point out that unmasking the unit won't change the outcome.