### PR TITLE
Add contrib script that replicates vixie cron mail subject/from

### DIFF
--- a/contrib/sendmail-ala-vixie
+++ b/contrib/sendmail-ala-vixie
@@ -1,0 +1,48 @@
+#!/bin/sh
+# https://github.com/systemd-cron/systemd-cron/issues/166
+#
+# sd-cron default:
+#   From: root
+#   Subject: [$(hostname)] Failure: $USER's crontab "cron-command"
+#
+# vixie cron:
+#   From: (Cron Daemon) <$USER@$(hostname -f)>
+#   Subject: Cron <$USER@$(hostname)> cron-command
+#
+# $user inherited in the environment from mail_for_job.sh
+
+{
+	hostname="$(hostname -f)"
+	while read -r header rest; do
+		case "$header" in
+			"")
+				echo
+				exec cat
+				;;
+			From:)
+				printf 'From: (Cron Daemon) <%s@%s>\n' "$user" "$hostname"
+				;;
+			Subject:)
+				rest="${rest%\"}"
+				rest="${rest#*\"}"
+				# down to '0   0    *   *     *   cd /home/...' (or '@daily cd /home/...')
+				if [ "${rest#@}" != "$rest" ]; then
+					rest="${rest#*[ 	]}"
+				else
+					rest="${rest#*[ 	]}"; rest="${rest#*[! 	]}"
+					rest="${rest#*[ 	]}"; rest="${rest#*[! 	]}"
+					rest="${rest#*[ 	]}"; rest="${rest#*[! 	]}"
+					rest="${rest#*[ 	]}"; rest="${rest#*[! 	]}"
+					rest="${rest#*[ 	]}"
+				fi
+				while [ "${rest#[ 	]}" != "$rest" ]; do
+					rest="${rest#[ 	]}"
+				done
+				printf 'Subject: Cron <%s@%s> %s\n' "$user" "${hostname%%.*}" "$rest"
+				;;
+			*)
+				printf '%s %s\n' "$header" "$rest"
+				;;
+		esac
+	done
+} | "$(command -v sendmail || command -v /usr/sbin/sendmail || command -v /usr/lib/sendmail)" "$@"

--- a/src/bin/mail_for_job.sh
+++ b/src/bin/mail_for_job.sh
@@ -48,6 +48,7 @@ systemctl show --property=User --property=Environment --property=SourcePath --pr
 	# Description is either »[Cron] "0 * * * * program"« or »[Cron] /etc/crontab«; we don't care about the latter
 	[ "${description#'[Cron] "'}" != "$description" ] && source_path="$source_path ${description#'[Cron] '}"
 
+	export user
 	mailto="$user"
 	mailfrom='root'
 


### PR DESCRIPTION
Sometimes it's ideal to replicate how vixie cron sends mail, to ease switching to systemd-cron.

Closes #166 