### PR TITLE
cron.target Conflicts= with traditional crond.service

### DIFF
--- a/src/units/cron.target.in
+++ b/src/units/cron.target.in
@@ -3,6 +3,7 @@ Description=systemd-cron
 Documentation=man:systemd.cron(7)
 @requires@
 Wants=cron-update.path
+Conflicts=crond.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Updated `contrib/census.txt` to reflect Fedora accurately.
- Added support for systemd's "preset" directory across `./configure` and the Makefile.
- Added the reworked spec-file for fedora
- Updated README
- Also in README reflected fedora's availability in the copr.

Some notes:
- Should remove the spec-file once package is upstreamed into fedora repos.
- Still using `sysusers`; systemd's `/usr/lib/userdb` JSON interface can't be used until some issues sorted
- Everything's fine anyways now...