### PR TITLE
Support for systemd preset dir (optionally)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -106,7 +106,9 @@ install: all
 	install -m755 -D $(builddir)/bin/mail_for_job $(DESTDIR)$(libexecdir)/systemd-cron/mail_for_job
 	install -m755 -D $(builddir)/bin/boot_delay $(DESTDIR)$(libexecdir)/systemd-cron/boot_delay
 	install -m644 -D $(srcdir)/lib/sysusers.d/systemd-cron.conf $(DESTDIR)$(sysusersdir)/systemd-cron.conf
+ifdef presetdir
 	install -m644 -D $(srcdir)/lib/50-systemd-cron.preset $(DESTDIR)$(presetdir)/50-systemd-cron.preset
+endif
 	install -m755 -D $(builddir)/bin/crontab_setgid $(DESTDIR)$(libexecdir)/systemd-cron/crontab_setgid
 
 	install -m644 -D $(builddir)/man/systemd.cron.7 $(DESTDIR)$(mandir)/man7/systemd.cron.7

--- a/Makefile.in
+++ b/Makefile.in
@@ -24,6 +24,7 @@ mandir		:= @mandir@
 docdir		:= @docdir@
 unitdir		:= @unitdir@
 generatordir	:= @generatordir@
+presetdir       := @presetdir@
 sysusersdir	:= @sysusersdir@
 
 srcdir		:= $(CURDIR)/src
@@ -105,6 +106,7 @@ install: all
 	install -m755 -D $(builddir)/bin/mail_for_job $(DESTDIR)$(libexecdir)/systemd-cron/mail_for_job
 	install -m755 -D $(builddir)/bin/boot_delay $(DESTDIR)$(libexecdir)/systemd-cron/boot_delay
 	install -m644 -D $(srcdir)/lib/sysusers.d/systemd-cron.conf $(DESTDIR)$(sysusersdir)/systemd-cron.conf
+	install -m644 -D $(srcdir)/lib/50-systemd-cron.preset $(DESTDIR)$(presetdir)/50-systemd-cron.preset
 	install -m755 -D $(builddir)/bin/crontab_setgid $(DESTDIR)$(libexecdir)/systemd-cron/crontab_setgid
 
 	install -m644 -D $(builddir)/man/systemd.cron.7 $(DESTDIR)$(mandir)/man7/systemd.cron.7
@@ -117,6 +119,7 @@ install: all
 	install -m644 $(builddir)/units/cron-update.path $(DESTDIR)$(unitdir)
 	install -m644 $(builddir)/units/cron-update.service $(DESTDIR)$(unitdir)
 	install -m644 $(builddir)/units/cron-mail@.service $(DESTDIR)$(unitdir)
+
 
 ifneq ($(enable_runparts),no)
 	$(foreach schedule,$(schedules),\

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Other options include (`pkgconf` may be overridden with `$PKG_CONFIG`):
 * `--unitdir=<path>` Path to systemd unit files.
   Default: `pkgconf systemd --variable=systemdsystemunitdir` or `<libdir>/systemd/system`.
 * `--presetdir=<path>` Path to systemd preset files
-  Default: `pkgconf systemd --variable=systemdsystempresetdir` or `<libdir>/systemd/system-preset`
+  Default: Needs to be explicitly set to be used; Usually can be `pkgconf systemd --variable=systemdsystempresetdir` or `<libdir>/systemd/system-preset`
 * `--generatordir=<path>` Path to systemd generators.
   Default: `pkgconf systemd --variable=systemdsystemgeneratordir` or `<libdir>/systemd/system-generators`.
 * `--sysusersdir=<path>` Path to systemd-sysusers snippets.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Other options include (`pkgconf` may be overridden with `$PKG_CONFIG`):
   Default: `no`.
 * `--unitdir=<path>` Path to systemd unit files.
   Default: `pkgconf systemd --variable=systemdsystemunitdir` or `<libdir>/systemd/system`.
+* `--presetdir=<path>` Path to systemd preset files
+  Default: `pkgconf systemd --variable=systemdsystempresetdir` or `<libdir>/systemd/system-preset`
 * `--generatordir=<path>` Path to systemd generators.
   Default: `pkgconf systemd --variable=systemdsystemgeneratordir` or `<libdir>/systemd/system-generators`.
 * `--sysusersdir=<path>` Path to systemd-sysusers snippets.

--- a/configure
+++ b/configure
@@ -27,9 +27,9 @@ unitdir='$(libdir)/systemd/system'
 # shellcheck disable=SC2016
 generatordir="$($pkgconf systemd --variable=systemdsystemgeneratordir)" 2>/dev/null || \
 generatordir='$(libdir)/systemd/system-generators'
-#
-presetdir="$($pkgconf systemd --variable=systemdsystempresetdir)" 2>/dev/null || \
-presetdir='$(libdir)/systemd/system-preset'
+# Don't set the presetdir unless manually passed
+#presetdir="$($pkgconf systemd --variable=systemdsystempresetdir)" 2>/dev/null || \
+#presetdir='$(libdir)/systemd/system-preset'
 # shellcheck disable=SC2016
 sysusersdir="$($pkgconf systemd --variable=sysusersdir)" 2>/dev/null || \
 sysusersdir='$(libdir)/sysusers.d'
@@ -287,6 +287,7 @@ s|@mandir@|${mandir}|g
 s|@docdir@|${docdir}|g
 s|@unitdir@|${unitdir}|g
 s|@generatordir@|${generatordir}|g
+s|@presetdir@|${presetdir:-""}|g
 s|@sysusersdir@|${sysusersdir}|g
 s|@libmd@|${libmd}|g
 s|@use_loglevelmax@|${use_loglevelmax}|g

--- a/configure
+++ b/configure
@@ -27,6 +27,9 @@ unitdir='$(libdir)/systemd/system'
 # shellcheck disable=SC2016
 generatordir="$($pkgconf systemd --variable=systemdsystemgeneratordir)" 2>/dev/null || \
 generatordir='$(libdir)/systemd/system-generators'
+#
+presetdir="$($pkgconf systemd --variable=systemdsystempresetdir)" 2>/dev/null || \
+presetdir='$(libdir)/systemd/system-preset'
 # shellcheck disable=SC2016
 sysusersdir="$($pkgconf systemd --variable=sysusersdir)" 2>/dev/null || \
 sysusersdir='$(libdir)/sysusers.d'
@@ -162,6 +165,9 @@ do
         '--generatordir')
             generatordir="${2}"
             shift 2;;
+	'--presetdir')
+	   presetdir="${2}"
+	   shift 2;;
 
         '--sysusersdir')
             sysusersdir="${2}"

--- a/src/lib/50-systemd-cron.preset
+++ b/src/lib/50-systemd-cron.preset
@@ -1,0 +1,1 @@
+enable cron.target


### PR DESCRIPTION
systemd supports a "preset" concept via `systemctl preset`, which basically in our context lets the packager tell the "default" state as enabled/disabled.

This PR adds support for that concept, but only if explicitly requested (not all distributions use it).
The exact application of this in systemd-cron is to enable `cron.target` by default, right after installation.

Via `--presetdir=<path>` to `./configure`, one can enable this feature.

But if that argument isn't passed then this feature is left disabled.
(But the README has suggestions for what to use, for those in the dark)
