### PR TITLE
Add CRON_BATCH_LOADAVG_BELOW=

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -25,6 +25,7 @@ docdir		:= @docdir@
 unitdir		:= @unitdir@
 generatordir	:= @generatordir@
 sysusersdir	:= @sysusersdir@
+tmpfilesdir	:= @tmpfilesdir@
 
 srcdir		:= $(CURDIR)/src
 outdir		:= $(CURDIR)/out
@@ -101,10 +102,12 @@ test-nounshare: all
 install: all
 	install -m755 -D $(builddir)/bin/crontab $(DESTDIR)$(bindir)/$(CRONTAB)
 	install -m755 -D $(builddir)/bin/systemd-crontab-generator $(DESTDIR)$(generatordir)/systemd-crontab-generator
+	install -m755 -D $(builddir)/bin/loadavg_dam $(DESTDIR)$(libexecdir)/systemd-cron/loadavg_dam
 	install -m755 -D $(builddir)/bin/remove_stale_stamps $(DESTDIR)$(libexecdir)/systemd-cron/remove_stale_stamps
 	install -m755 -D $(builddir)/bin/mail_for_job $(DESTDIR)$(libexecdir)/systemd-cron/mail_for_job
 	install -m755 -D $(builddir)/bin/boot_delay $(DESTDIR)$(libexecdir)/systemd-cron/boot_delay
 	install -m644 -D $(srcdir)/lib/sysusers.d/systemd-cron.conf $(DESTDIR)$(sysusersdir)/systemd-cron.conf
+	install -m644 -D $(srcdir)/lib/tmpfiles.d/systemd-cron.conf $(DESTDIR)$(tmpfilesdir)/systemd-cron.conf
 	install -m755 -D $(builddir)/bin/crontab_setgid $(DESTDIR)$(libexecdir)/systemd-cron/crontab_setgid
 
 	install -m644 -D $(builddir)/man/systemd.cron.7 $(DESTDIR)$(mandir)/man7/systemd.cron.7
@@ -222,6 +225,7 @@ endif
 common_headers := $(builddir)/include/configuration.hpp $(builddir)/include/libvoreutils.hpp$(if $(PCH),.gch) $(builddir)/include/util.hpp
 CFLAGS   += -Wall -Wextra -fno-exceptions -Wno-psabi
 CXXFLAGS += -Wall -Wextra -fno-exceptions -Wno-psabi
+LDFLAGS  += -Wl,-as-needed
 $(builddir)/include/libvoreutils.hpp.gch : $(builddir)/include/libvoreutils.hpp
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS)            -std=c++20 -I $(builddir)/include            $< -o $@
 
@@ -230,6 +234,9 @@ $(builddir)/bin/systemd-crontab-generator: $(srcdir)/bin/systemd-crontab-generat
 
 $(builddir)/bin/crontab: $(srcdir)/bin/crontab.cpp $(common_headers)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -std=c++20 -I $(builddir)/include $(PCH_ARG) $< -o $@ $(LDLIBS)
+
+$(builddir)/bin/loadavg_dam: $(srcdir)/bin/loadavg_dam.cpp $(common_headers)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -std=c++20 -I $(builddir)/include $(PCH_ARG) $< -o $@ $(LDLIBS) -latomic -lrt
 
 $(builddir)/bin/%: $(srcdir)/bin/%.sh
 	$(call in2out,$<,$@)

--- a/configure
+++ b/configure
@@ -30,6 +30,9 @@ generatordir='$(libdir)/systemd/system-generators'
 # shellcheck disable=SC2016
 sysusersdir="$($pkgconf systemd --variable=sysusersdir)" 2>/dev/null || \
 sysusersdir='$(libdir)/sysusers.d'
+# shellcheck disable=SC2016
+tmpfilesdir="$($pkgconf systemd --variable=tmpfilesdir)" 2>/dev/null || \
+tmpfilesdir='$(libdir)/tmpfiles.d'
 libmd="$($pkgconf --cflags --libs libmd)" 2>/dev/null || \
 libmd='-lmd'
 enable_runparts=no
@@ -70,6 +73,7 @@ docdir:,
 unitdir:,
 generatordir:,
 sysusersdir:,
+tmpfilesdir:,
 enable-boot::,
 enable-minutely::,
 enable-hourly::,
@@ -165,6 +169,10 @@ do
 
         '--sysusersdir')
             sysusersdir="${2}"
+            shift 2;;
+
+        '--tmpfilesdir')
+            tmpfilesdir="${2}"
             shift 2;;
 
         '--libmd')
@@ -282,6 +290,7 @@ s|@docdir@|${docdir}|g
 s|@unitdir@|${unitdir}|g
 s|@generatordir@|${generatordir}|g
 s|@sysusersdir@|${sysusersdir}|g
+s|@tmpfilesdir@|${tmpfilesdir}|g
 s|@libmd@|${libmd}|g
 s|@use_loglevelmax@|${use_loglevelmax}|g
 s|@part2timer@|${part2timer}|g

--- a/src/bin/loadavg_dam.cpp
+++ b/src/bin/loadavg_dam.cpp
@@ -1,0 +1,89 @@
+/* Copyright (C) 2025 наб (nabijaczleweli@nabijaczleweli.xyz)
+ * SPDX-License-Identifier: 0BSD
+ *
+ * For jobs like {below_loadavg: double, spawn: void()}, this executes
+ *   for(;;) {
+ *     sleep(30);
+ *     while(!(j = find_random_if(jobs, j => j.below_loadavg < getloadavg()))
+ *       sleep(5);
+ *     j.spawn();
+ *   }
+ * via the swarm of pending jobs.
+ *
+ * lodavg_dam targets ExecStartPre=, so spawn=exit(3).
+ */
+
+#include "libvoreutils.hpp"
+#include <atomic>
+#include <type_traits>
+
+
+namespace {
+	struct bundle {
+		static const constexpr std::size_t PIDBITS    = 22;  // 2^22 is the current max max (but any max is ok)
+		static const constexpr std::size_t SUBSECBITS = 64 - 32 - PIDBITS;
+		std::uint64_t last_winner : PIDBITS;   // the process that was dispatched
+		std::uint64_t last_time_won_sec : 32;  // last time a process was dispatched
+		std::uint64_t last_time_won_subsec : SUBSECBITS;
+
+		bundle(pid_t pid, const struct timespec & now)
+		      : last_winner(0), last_time_won_sec(now.tv_sec),
+		        last_time_won_subsec(static_cast<std::uint64_t>(now.tv_nsec) * (1llu << SUBSECBITS) / 1'000'000'000) {
+			std::make_unsigned_t<pid_t> pidbits = pid;
+			for(int left = sizeof(pidbits) * 8; left > 0; left -= PIDBITS, pidbits >>= PIDBITS)
+				this->last_winner ^= pidbits & ((1u << PIDBITS) - 1);
+		}
+
+		operator struct timespec() const { return {this->last_time_won_sec, this->last_time_won_subsec}; }
+	};
+	static_assert(sizeof(bundle) == sizeof(std::uint64_t));
+
+	// All-0 is a valid initial state for this, so ftruncate() is a valid initialiser
+	using shm_t = std::atomic<struct bundle>;
+}
+
+
+auto main(int, const char * const * argv) -> int {
+	const auto self = *argv++;
+	if(*argv && *argv == "--"sv)
+		++argv;
+	if(!*argv || *(argv + 1))
+		return std::fprintf(stderr, "usage: %s below-loadavg\n", self), 1;
+
+	double target;
+	if(auto err = vore::parse_floating(*argv, target))
+		return std::fprintf(stderr, "%s: %s: %s\n", self, *argv, err), 1;
+	if(target <= 0)
+		return std::fprintf(stderr, "%s: %s: %s\n", self, *argv, "<= 0"), 1;
+
+
+	auto shm_f = shm_open("/systemd-cron", O_RDWR | O_CREAT, 0644);
+	if(shm_f == -1)
+		return std::fprintf(stderr, "%s: %s: %s\n", self, "/systemd-cron", std::strerror(errno)), 1;
+
+	if(ftruncate(shm_f, sizeof(shm_t)))
+		return std::fprintf(stderr, "%s: %s\n", self, std::strerror(errno)), 1;
+
+	auto shm = static_cast<shm_t *>(mmap(nullptr, sizeof(shm_t), PROT_READ | PROT_WRITE, MAP_SHARED, shm_f, 0));
+	if(shm == MAP_FAILED)
+		return std::fprintf(stderr, "%s: %s\n", self, std::strerror(errno)), 1;
+
+	close(shm_f);
+
+
+	for(const auto pid = getpid();; sleep(5)) {
+		const auto last = shm->load();
+
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC_COARSE, &now);
+		if((now - last) > (struct timespec){30, 0}) {
+			if(double load; getloadavg(&load, 1) != 1 || load > target)
+				continue;  // load too high
+
+			if(auto value = last; !shm->compare_exchange_strong(value, {pid, now}))
+				continue;  // we lost
+
+			break;
+		}
+	}
+}

--- a/src/bin/systemd-crontab-generator.cpp
+++ b/src/bin/systemd-crontab-generator.cpp
@@ -164,6 +164,7 @@ struct Job {
 	std::size_t start_hour;
 	bool persistent;
 	bool batch;
+	std::string_view cron_batch_loadavg_below;
 	std::string jobid;
 	std::string unit_name;
 	std::string_view user;
@@ -295,6 +296,8 @@ struct Job {
 					this->log(Log::WARNING, "invalid DELAY");
 			} else if(k == "BATCH"sv)
 				this->batch = systemd_bool(v);
+			else if(k == "CRON_BATCH_LOADAVG_BELOW"sv)
+				this->cron_batch_loadavg_below = v;
 			else if(k == "CRON_MAIL_SUCCESS"sv) {
 				if(v == "never"sv || systemd_bool_false(v))
 					this->cron_mail_success = cron_mail_success_t::never;
@@ -899,9 +902,14 @@ struct Job {
 		std::fputs("SyslogFacility=cron\n", into);
 		if(USE_LOGLEVELMAX != "no"sv)
 			std::fprintf(into, "LogLevelMax=%.*s\n", FORMAT_SV(USE_LOGLEVELMAX));
+		bool have_startpre{};
 		if(!this->schedule.empty() && this->boot_delay)
 			if(!UPTIME || this->boot_delay > *UPTIME)
-				std::fprintf(into, "ExecStartPre=-%.*s %zu\n", FORMAT_SV(BOOT_DELAY), this->boot_delay);
+				std::fprintf(into, "ExecStartPre=-%s %zu\n", BOOT_DELAY, this->boot_delay), have_startpre = true;
+		if(!this->cron_batch_loadavg_below.empty())
+			std::fprintf(into, "ExecStartPre=!%s %.*s\n", LOADAVG_DAM, FORMAT_SV(this->cron_batch_loadavg_below)), have_startpre = true;
+		if(have_startpre)
+			std::fputs("TimeoutStartSec=infinity\n", into);
 		std::fprintf(into, "ExecStart=%.*s\n", FORMAT_SV(this->execstart));
 		if(onsuccess_shim) {
 			std::fputs(onsuccess_shim, into);

--- a/src/include/configuration.hpp.in
+++ b/src/include/configuration.hpp.in
@@ -5,7 +5,8 @@ static const char * const VERSION                       = "@version@";
 static const constexpr std::string_view USE_LOGLEVELMAX = "@use_loglevelmax@"sv;
 static const constexpr bool USE_RUNPARTS                = @use_runparts@;
 static const constexpr bool HAVE_ONSUCCESS              = @have_onsuccess@;
-static const constexpr std::string_view BOOT_DELAY      = "@libexecdir@/systemd-cron/boot_delay"sv;
+static const char * const BOOT_DELAY                    = "@libexecdir@/systemd-cron/boot_delay";
+static const char * const LOADAVG_DAM                   = "@libexecdir@/systemd-cron/loadavg_dam";
 #define STATEDIR "@statedir@"
 static const char * const SETGID_HELPER                 = "@libexecdir@/systemd-cron/crontab_setgid";
 #define PAMNAME "@pamname@"  // ignore if empty

--- a/src/include/libvoreutils.hpp
+++ b/src/include/libvoreutils.hpp
@@ -436,4 +436,41 @@ namespace vore {
 		overload(Ts...) -> overload<Ts...>;
 	}
 }
+
+
+namespace vore {
+	namespace {
+		[[maybe_unused]]
+		const char * parse_floating(const char * val, double & out) {
+			char * end{};
+			errno = 0;
+			out   = std::strtod(val, &end);
+			if(out == 0 && end == val)
+				return "invalid";
+			else if(end && *end)
+				return "partial conversion";
+			else if(errno)
+				return std::strerror(errno);
+
+			return std::isnan(out) ? "is NaN" : nullptr;
+		}
+	}
+}
+
+
+[[maybe_unused]]
+constexpr static bool operator>(const struct timespec & lhs, const struct timespec & rhs) {
+	return lhs.tv_sec > rhs.tv_sec || (lhs.tv_sec == rhs.tv_sec && lhs.tv_nsec > rhs.tv_nsec);
+}
+
+[[maybe_unused]]
+constexpr static struct timespec operator-(struct timespec lhs, const struct timespec & rhs) {
+	if(rhs.tv_nsec > lhs.tv_nsec) {
+		lhs.tv_sec -= 1;
+		lhs.tv_nsec += 1'000'000'000;
+	}
+	lhs.tv_nsec -= rhs.tv_nsec;
+	lhs.tv_sec -= rhs.tv_sec;
+	return lhs;
+}
 #endif

--- a/src/lib/tmpfiles.d/systemd-cron.conf
+++ b/src/lib/tmpfiles.d/systemd-cron.conf
@@ -1,0 +1,1 @@
+f /dev/shm/systemd-cron 0644 root root

--- a/src/man/crontab.5.in
+++ b/src/man/crontab.5.in
@@ -227,6 +227,11 @@ and
 .B IOSchedulingClass=idle
 when set.
 
+.TP
+.B CRON_BATCH_LOADAVG_BELOW
+If set and nonempty, delay starting the job until the 1-minute system load average drops below the set value.
+All jobs using this option join a global queue scheduling a random eligible job every 30s.
+
 .PP
 The format of a
 .B cron command

--- a/src/man/systemd.cron.7.in
+++ b/src/man/systemd.cron.7.in
@@ -55,6 +55,10 @@ System crontabs managed by packages live here.
 .It Pa @statedir@
 Users' crontabs live here.
 .
+.It Pa /dev/shm/systemd-cron
+Queue used for
+.Sy CRON_BATCH_LOADAVG_BELOW .
+.
 .Pp
 .de etccron
 .if \\n[etccron_\\$1] \{ .

--- a/test/test-generator
+++ b/test/test-generator
@@ -106,6 +106,11 @@ assert_dat() {  # file content testname
 	              'CRON_MAIL_FORMAT=inherit'                                  \
 	              '* * * * * dummy :'                                         \
 	              'CRON_MAIL_FORMAT=no-metadata'                              \
+	              '* * * * * dummy :'                                         \
+	                                                                          \
+	              'CRON_BATCH_LOADAVG_BELOW=10'                               \
+	              '* * * * * dummy :'                                         \
+	              'CRON_BATCH_LOADAVG_BELOW='                                 \
 	              '* * * * * dummy :'                                         > /etc/crontab
 	printf '%s\n' '# test_MAIL_inherit_default'                               \
 	              '* * * * * dummy !'                                         \
@@ -188,6 +193,11 @@ assert_dat() {  # file content testname
 	assert_key cron-crontab-dummy-18.service 'OnFailure' 'cron-mail@%n:Failure.service'                     test_cron_mail_format=inherit
 	assert_key cron-crontab-dummy-19.service 'OnSuccess' 'cron-mail@%n:Success:nonempty:nometadata.service' test_cron_mail_format=no-metadata
 	assert_key cron-crontab-dummy-19.service 'OnFailure' 'cron-mail@%n:Failure:nometadata.service'          test_cron_mail_format=no-metadata
+	assert_ney cron-crontab-dummy-19.service 'TimeoutStartSec'                                              test_cron_mail_format=no-metadata
+	assert_key cron-crontab-dummy-20.service 'ExecStartPre'    "!/usr/libexec/systemd-cron/loadavg_dam 10"  test_cron_batch_loadavg_below=10
+	assert_key cron-crontab-dummy-20.service 'TimeoutStartSec' 'infinity'                                   test_cron_batch_loadavg_below=10
+	assert_ney cron-crontab-dummy-21.service 'ExecStartPre'                                                 test_cron_batch_loadavg_below=10
+	assert_ney cron-crontab-dummy-21.service 'TimeoutStartSec'                                              test_cron_batch_loadavg_below=10
 
 	assert_key cron-crondtab-dummy-0.service 'OnSuccess' 'cron-mail@%n:Success:nonempty:nometadata.service' test_MAIL_inherit_default
 	assert_key cron-crondtab-dummy-0.service 'OnFailure' 'cron-mail@%n:Failure:nometadata.service'          test_MAIL_inherit_default
@@ -342,6 +352,7 @@ then
 
 	assert_key cron-daily-id.service  'Description'       '[Cron] /etc/cron.daily/id'                /etc/cron.daily
 	assert_key cron-daily-id.service  'ExecStartPre'      '-/usr/libexec/systemd-cron/boot_delay 10' /etc/cron.daily    # hourly.daily = 2nd, *5min for each longer one
+	assert_key cron-daily-id.service  'TimeoutStartSec'   'infinity'                                 /etc/cron.daily
 	assert_key cron-daily-id.service  'ExecStart'         '/etc/cron.daily/id'                       /etc/cron.daily
 	assert_key cron-daily-id.timer    'OnCalendar'        '*-*-* 5:10:0'                             /etc/cron.daily
 	assert_key cron-daily-id.timer    'Persistent'        'true'                                     /etc/cron.daily


### PR DESCRIPTION
`CRON_BATCH_LOADAVG_BELOW=$value` generates `ExecStartPre=!/.../loadavg_dam $value`: multiple optionally-concurrent loadavg_dam processes form a global persistent queue which makes exactly one process for which `(1-minute loadavg) < $value` exit no sooner than 30s after the last process exited the queue

If I understood #173 right, this should cover @pabs3's case:
```perl
CRON_BATCH_LOADAVG_BELOW=10
  0   0    *   *     *   cd ...
  0   0    *   *     *   dd ...
```
will wait until 1-minute loadavg is <10, spawn one, wait 30s, (if loadavg is <10: spawn the other; otherwise: sleep 5s, back to `(`).