### PR TITLE
 Add CRON_BATCH_LOADAVG_BELOW=, CRON_BATCH_THROTTLE_GROUP=

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -103,6 +103,7 @@ install: all
 	install -m755 -D $(builddir)/bin/crontab $(DESTDIR)$(bindir)/$(CRONTAB)
 	install -m755 -D $(builddir)/bin/systemd-crontab-generator $(DESTDIR)$(generatordir)/systemd-crontab-generator
 	install -m755 -D $(builddir)/bin/loadavg_dam $(DESTDIR)$(libexecdir)/systemd-cron/loadavg_dam
+	install -m755 -D $(builddir)/bin/throttle_group $(DESTDIR)$(libexecdir)/systemd-cron/throttle_group
 	install -m755 -D $(builddir)/bin/remove_stale_stamps $(DESTDIR)$(libexecdir)/systemd-cron/remove_stale_stamps
 	install -m755 -D $(builddir)/bin/mail_for_job $(DESTDIR)$(libexecdir)/systemd-cron/mail_for_job
 	install -m755 -D $(builddir)/bin/boot_delay $(DESTDIR)$(libexecdir)/systemd-cron/boot_delay
@@ -235,8 +236,12 @@ $(builddir)/bin/systemd-crontab-generator: $(srcdir)/bin/systemd-crontab-generat
 $(builddir)/bin/crontab: $(srcdir)/bin/crontab.cpp $(common_headers)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -std=c++20 -I $(builddir)/include $(PCH_ARG) $< -o $@ $(LDLIBS)
 
+common_headers += $(builddir)/include/shmemutil.hpp
 $(builddir)/bin/loadavg_dam: $(srcdir)/bin/loadavg_dam.cpp $(common_headers)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -std=c++20 -I $(builddir)/include $(PCH_ARG) $< -o $@ $(LDLIBS) -latomic -lrt
+
+$(builddir)/bin/throttle_group: $(srcdir)/bin/throttle_group.cpp $(common_headers)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -std=c++20 -I $(builddir)/include $(PCH_ARG) $< -o $@ $(LDLIBS) -latomic -lrt @libsystemd@
 
 $(builddir)/bin/%: $(srcdir)/bin/%.sh
 	$(call in2out,$<,$@)

--- a/Makefile.in
+++ b/Makefile.in
@@ -25,6 +25,7 @@ docdir		:= @docdir@
 unitdir		:= @unitdir@
 generatordir	:= @generatordir@
 sysusersdir	:= @sysusersdir@
+tmpfilesdir	:= @tmpfilesdir@
 
 srcdir		:= $(CURDIR)/src
 outdir		:= $(CURDIR)/out
@@ -101,10 +102,12 @@ test-nounshare: all
 install: all
 	install -m755 -D $(builddir)/bin/crontab $(DESTDIR)$(bindir)/$(CRONTAB)
 	install -m755 -D $(builddir)/bin/systemd-crontab-generator $(DESTDIR)$(generatordir)/systemd-crontab-generator
+	install -m755 -D $(builddir)/bin/loadavg_dam $(DESTDIR)$(libexecdir)/systemd-cron/loadavg_dam
 	install -m755 -D $(builddir)/bin/remove_stale_stamps $(DESTDIR)$(libexecdir)/systemd-cron/remove_stale_stamps
 	install -m755 -D $(builddir)/bin/mail_for_job $(DESTDIR)$(libexecdir)/systemd-cron/mail_for_job
 	install -m755 -D $(builddir)/bin/boot_delay $(DESTDIR)$(libexecdir)/systemd-cron/boot_delay
 	install -m644 -D $(srcdir)/lib/sysusers.d/systemd-cron.conf $(DESTDIR)$(sysusersdir)/systemd-cron.conf
+	install -m644 -D $(srcdir)/lib/tmpfiles.d/systemd-cron.conf $(DESTDIR)$(tmpfilesdir)/systemd-cron.conf
 	install -m755 -D $(builddir)/bin/crontab_setgid $(DESTDIR)$(libexecdir)/systemd-cron/crontab_setgid
 
 	install -m644 -D $(builddir)/man/systemd.cron.7 $(DESTDIR)$(mandir)/man7/systemd.cron.7
@@ -222,6 +225,7 @@ endif
 common_headers := $(builddir)/include/configuration.hpp $(builddir)/include/libvoreutils.hpp$(if $(PCH),.gch) $(builddir)/include/util.hpp
 CFLAGS   += -Wall -Wextra -fno-exceptions -Wno-psabi
 CXXFLAGS += -Wall -Wextra -fno-exceptions -Wno-psabi
+LDFLAGS  += -Wl,-as-needed
 $(builddir)/include/libvoreutils.hpp.gch : $(builddir)/include/libvoreutils.hpp
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS)            -std=c++20 -I $(builddir)/include            $< -o $@
 
@@ -230,6 +234,9 @@ $(builddir)/bin/systemd-crontab-generator: $(srcdir)/bin/systemd-crontab-generat
 
 $(builddir)/bin/crontab: $(srcdir)/bin/crontab.cpp $(common_headers)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -std=c++20 -I $(builddir)/include $(PCH_ARG) $< -o $@ $(LDLIBS)
+
+$(builddir)/bin/loadavg_dam: $(srcdir)/bin/loadavg_dam.cpp $(common_headers)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -std=c++20 -I $(builddir)/include $(PCH_ARG) $< -o $@ $(LDLIBS) -latomic -lrt
 
 $(builddir)/bin/%: $(srcdir)/bin/%.sh
 	$(call in2out,$<,$@)

--- a/configure
+++ b/configure
@@ -30,6 +30,9 @@ generatordir='$(libdir)/systemd/system-generators'
 # shellcheck disable=SC2016
 sysusersdir="$($pkgconf systemd --variable=sysusersdir)" 2>/dev/null || \
 sysusersdir='$(libdir)/sysusers.d'
+# shellcheck disable=SC2016
+tmpfilesdir="$($pkgconf systemd --variable=tmpfilesdir)" 2>/dev/null || \
+tmpfilesdir='$(libdir)/tmpfiles.d'
 libmd="$($pkgconf --cflags --libs libmd)" 2>/dev/null || \
 libmd='-lmd'
 enable_runparts=no
@@ -70,6 +73,7 @@ docdir:,
 unitdir:,
 generatordir:,
 sysusersdir:,
+tmpfilesdir:,
 enable-boot::,
 enable-minutely::,
 enable-hourly::,
@@ -165,6 +169,10 @@ do
 
         '--sysusersdir')
             sysusersdir="${2}"
+            shift 2;;
+
+        '--tmpfilesdir')
+            tmpfilesdir="${2}"
             shift 2;;
 
         '--libmd')
@@ -282,6 +290,7 @@ s|@docdir@|${docdir}|g
 s|@unitdir@|${unitdir}|g
 s|@generatordir@|${generatordir}|g
 s|@sysusersdir@|${sysusersdir}|g
+s|@tmpfilesdir@|${tmpfilesdir}|g
 s|@libmd@|${libmd}|g
 s|@use_loglevelmax@|${use_loglevelmax}|g
 s|@part2timer@|${part2timer}|g

--- a/configure
+++ b/configure
@@ -35,6 +35,8 @@ tmpfilesdir="$($pkgconf systemd --variable=tmpfilesdir)" 2>/dev/null || \
 tmpfilesdir='$(libdir)/tmpfiles.d'
 libmd="$($pkgconf --cflags --libs libmd)" 2>/dev/null || \
 libmd='-lmd'
+libsystemd="$($pkgconf --cflags --libs libsystemd)" 2>/dev/null || \
+libsystemd='-lsystemd'
 enable_runparts=no
 use_loglevelmax=no
 part2timer=/dev/null
@@ -292,6 +294,7 @@ s|@generatordir@|${generatordir}|g
 s|@sysusersdir@|${sysusersdir}|g
 s|@tmpfilesdir@|${tmpfilesdir}|g
 s|@libmd@|${libmd}|g
+s|@libsystemd@|${libsystemd}|g
 s|@use_loglevelmax@|${use_loglevelmax}|g
 s|@part2timer@|${part2timer}|g
 s|@crond2timer@|${crond2timer}|g

--- a/src/bin/loadavg_dam.cpp
+++ b/src/bin/loadavg_dam.cpp
@@ -13,34 +13,8 @@
  * lodavg_dam targets ExecStartPre=, so spawn=exit(3).
  */
 
-#include "libvoreutils.hpp"
-#include <atomic>
-#include <type_traits>
-
-
-namespace {
-	struct bundle {
-		static const constexpr std::size_t PIDBITS    = 22;  // 2^22 is the current max max (but any max is ok)
-		static const constexpr std::size_t SUBSECBITS = 64 - 32 - PIDBITS;
-		std::uint64_t last_winner : PIDBITS;   // the process that was dispatched
-		std::uint64_t last_time_won_sec : 32;  // last time a process was dispatched
-		std::uint64_t last_time_won_subsec : SUBSECBITS;
-
-		bundle(pid_t pid, const struct timespec & now)
-		      : last_winner(0), last_time_won_sec(now.tv_sec),
-		        last_time_won_subsec(static_cast<std::uint64_t>(now.tv_nsec) * (1llu << SUBSECBITS) / 1'000'000'000) {
-			std::make_unsigned_t<pid_t> pidbits = pid;
-			for(int left = sizeof(pidbits) * 8; left > 0; left -= PIDBITS, pidbits >>= PIDBITS)
-				this->last_winner ^= pidbits & ((1u << PIDBITS) - 1);
-		}
-
-		operator struct timespec() const { return {this->last_time_won_sec, this->last_time_won_subsec}; }
-	};
-	static_assert(sizeof(bundle) == sizeof(std::uint64_t));
-
-	// All-0 is a valid initial state for this, so ftruncate() is a valid initialiser
-	using shm_t = std::atomic<struct bundle>;
-}
+#define SHMEM_FILE "systemd-cron.loadavg_dam"
+#include "shmemutil.hpp"
 
 
 auto main(int, const char * const * argv) -> int {
@@ -57,19 +31,9 @@ auto main(int, const char * const * argv) -> int {
 		return std::fprintf(stderr, "%s: %s: %s\n", self, *argv, "<= 0"), 1;
 
 
-	auto shm_f = shm_open("/systemd-cron", O_RDWR | O_CREAT, 0644);
-	if(shm_f == -1)
-		return std::fprintf(stderr, "%s: %s: %s\n", self, "/systemd-cron", std::strerror(errno)), 1;
-
-	if(ftruncate(shm_f, sizeof(shm_t)))
-		return std::fprintf(stderr, "%s: %s\n", self, std::strerror(errno)), 1;
-
-	auto shm = static_cast<shm_t *>(mmap(nullptr, sizeof(shm_t), PROT_READ | PROT_WRITE, MAP_SHARED, shm_f, 0));
-	if(shm == MAP_FAILED)
-		return std::fprintf(stderr, "%s: %s\n", self, std::strerror(errno)), 1;
-
-	close(shm_f);
-
+	shm_t * shm;
+	if(auto err = bundle::map(self, shm))
+		return err;
 
 	for(const auto pid = getpid();; sleep(5)) {
 		const auto last = shm->load();

--- a/src/bin/loadavg_dam.cpp
+++ b/src/bin/loadavg_dam.cpp
@@ -1,0 +1,89 @@
+/* Copyright (C) 2025 наб (nabijaczleweli@nabijaczleweli.xyz)
+ * SPDX-License-Identifier: 0BSD
+ *
+ * For jobs like {below_loadavg: double, spawn: void()}, this executes
+ *   for(;;) {
+ *     sleep(30);
+ *     while(!(j = find_random_if(jobs, j => j.below_loadavg < getloadavg()))
+ *       sleep(5);
+ *     j.spawn();
+ *   }
+ * via the swarm of pending jobs.
+ *
+ * lodavg_dam targets ExecStartPre=, so spawn=exit(3).
+ */
+
+#include "libvoreutils.hpp"
+#include <atomic>
+#include <type_traits>
+
+
+namespace {
+	struct bundle {
+		static const constexpr std::size_t PIDBITS    = 22;  // 2^22 is the current max max (but any max is ok)
+		static const constexpr std::size_t SUBSECBITS = 64 - 32 - PIDBITS;
+		std::uint64_t last_winner : PIDBITS;   // the process that was dispatched
+		std::uint64_t last_time_won_sec : 32;  // last time a process was dispatched
+		std::uint64_t last_time_won_subsec : SUBSECBITS;
+
+		bundle(pid_t pid, const struct timespec & now)
+		      : last_winner(0), last_time_won_sec(now.tv_sec),
+		        last_time_won_subsec(static_cast<std::uint64_t>(now.tv_nsec) * (1llu << SUBSECBITS) / 1'000'000'000) {
+			std::make_unsigned_t<pid_t> pidbits = pid;
+			for(int left = sizeof(pidbits) * 8; left > 0; left -= PIDBITS, pidbits >>= PIDBITS)
+				this->last_winner ^= pidbits & ((1u << PIDBITS) - 1);
+		}
+
+		operator struct timespec() const { return {this->last_time_won_sec, this->last_time_won_subsec}; }
+	};
+	static_assert(sizeof(bundle) == sizeof(std::uint64_t));
+
+	// All-0 is a valid initial state for this, so ftruncate() is a valid initialiser
+	using shm_t = std::atomic<struct bundle>;
+}
+
+
+auto main(int, const char * const * argv) -> int {
+	const auto self = *argv++;
+	if(*argv && *argv == "--"sv)
+		++argv;
+	if(!*argv || *(argv + 1))
+		return std::fprintf(stderr, "usage: %s below-loadavg\n", self), 1;
+
+	double target;
+	if(auto err = vore::parse_floating(*argv, target))
+		return std::fprintf(stderr, "%s: %s: %s\n", self, *argv, err), 1;
+	if(target <= 0)
+		return std::fprintf(stderr, "%s: %s: %s\n", self, *argv, "<= 0"), 1;
+
+
+	auto shm_f = shm_open("/systemd-cron", O_RDWR | O_CREAT, 0644);
+	if(shm_f == -1)
+		return std::fprintf(stderr, "%s: %s: %s\n", self, "/systemd-cron", std::strerror(errno)), 1;
+
+	if(ftruncate(shm_f, sizeof(shm_t)))
+		return std::fprintf(stderr, "%s: %s\n", self, std::strerror(errno)), 1;
+
+	auto shm = static_cast<shm_t *>(mmap(nullptr, sizeof(shm_t), PROT_READ | PROT_WRITE, MAP_SHARED, shm_f, 0));
+	if(shm == MAP_FAILED)
+		return std::fprintf(stderr, "%s: %s\n", self, std::strerror(errno)), 1;
+
+	close(shm_f);
+
+
+	for(const auto pid = getpid();; sleep(5)) {
+		const auto last = shm->load();
+
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC_COARSE, &now);
+		if((now - last) > (struct timespec){30, 0}) {
+			if(double load; getloadavg(&load, 1) != 1 || load > target)
+				continue;  // load too high
+
+			if(auto value = last; !shm->compare_exchange_strong(value, {pid, now}))
+				continue;  // we lost
+
+			break;
+		}
+	}
+}

--- a/src/bin/systemd-crontab-generator.cpp
+++ b/src/bin/systemd-crontab-generator.cpp
@@ -165,6 +165,7 @@ struct Job {
 	bool persistent;
 	bool batch;
 	std::string_view cron_batch_loadavg_below;
+	std::string_view cron_batch_throttle_group;
 	std::string jobid;
 	std::string unit_name;
 	std::string_view user;
@@ -298,6 +299,8 @@ struct Job {
 				this->batch = systemd_bool(v);
 			else if(k == "CRON_BATCH_LOADAVG_BELOW"sv)
 				this->cron_batch_loadavg_below = v;
+			else if(k == "CRON_BATCH_THROTTLE_GROUP"sv)
+				this->cron_batch_throttle_group = v;
 			else if(k == "CRON_MAIL_SUCCESS"sv) {
 				if(v == "never"sv || systemd_bool_false(v))
 					this->cron_mail_success = cron_mail_success_t::never;
@@ -908,6 +911,8 @@ struct Job {
 				std::fprintf(into, "ExecStartPre=-%s %zu\n", BOOT_DELAY, this->boot_delay), have_startpre = true;
 		if(!this->cron_batch_loadavg_below.empty())
 			std::fprintf(into, "ExecStartPre=!%s %.*s\n", LOADAVG_DAM, FORMAT_SV(this->cron_batch_loadavg_below)), have_startpre = true;
+		if(!this->cron_batch_throttle_group.empty())
+			std::fprintf(into, "ExecStartPre=!%s %.*s\n", THROTTLE_GROUP, FORMAT_SV(this->cron_batch_throttle_group)), have_startpre = true;
 		if(have_startpre)
 			std::fputs("TimeoutStartSec=infinity\n", into);
 		std::fprintf(into, "ExecStart=%.*s\n", FORMAT_SV(this->execstart));

--- a/src/bin/systemd-crontab-generator.cpp
+++ b/src/bin/systemd-crontab-generator.cpp
@@ -164,6 +164,7 @@ struct Job {
 	std::size_t start_hour;
 	bool persistent;
 	bool batch;
+	std::string_view cron_batch_loadavg_below;
 	std::string jobid;
 	std::string unit_name;
 	std::string_view user;
@@ -295,6 +296,8 @@ struct Job {
 					this->log(Log::WARNING, "invalid DELAY");
 			} else if(k == "BATCH"sv)
 				this->batch = systemd_bool(v);
+			else if(k == "CRON_BATCH_LOADAVG_BELOW"sv)
+				this->cron_batch_loadavg_below = v;
 			else if(k == "CRON_MAIL_SUCCESS"sv) {
 				if(v == "never"sv || systemd_bool_false(v))
 					this->cron_mail_success = cron_mail_success_t::never;
@@ -899,9 +902,14 @@ struct Job {
 		std::fputs("SyslogFacility=cron\n", into);
 		if(USE_LOGLEVELMAX != "no"sv)
 			std::fprintf(into, "LogLevelMax=%.*s\n", FORMAT_SV(USE_LOGLEVELMAX));
+		bool have_startpre{};
 		if(!this->schedule.empty() && this->boot_delay)
 			if(!UPTIME || this->boot_delay > *UPTIME)
-				std::fprintf(into, "ExecStartPre=-%.*s %zu\n", FORMAT_SV(BOOT_DELAY), this->boot_delay);
+				std::fprintf(into, "ExecStartPre=-%s %zu\n", BOOT_DELAY, this->boot_delay), have_startpre = true;
+		if(!this->cron_batch_loadavg_below.empty())
+			std::fprintf(into, "ExecStartPre=!%s %.*s\n", LOADAVG_DAM, FORMAT_SV(this->cron_batch_loadavg_below)), have_startpre = true;
+		if(have_startpre)
+			std::fputs("TimeoutStartSec=infinity\n", into);
 		std::fprintf(into, "ExecStart=%.*s\n", FORMAT_SV(this->execstart));
 		if(onsuccess_shim) {
 			std::fputs(onsuccess_shim, into);

--- a/src/bin/throttle_group.cpp
+++ b/src/bin/throttle_group.cpp
@@ -1,0 +1,285 @@
+/* Copyright (C) 2025 наб (nabijaczleweli@nabijaczleweli.xyz)
+ * SPDX-License-Identifier: 0BSD
+ *
+ * Talk to systemd over org.freedesktop.systemd1(5) to:
+ * 1. find other jobs matching "cron-*.service" with ExecStartPre=argv[0] argv[1] [...]
+ * 2. sleep until 5 minutes after the last such job exited
+ * 3. atomically consume the current job slot, exit
+ *
+ * See https://github.com/systemd-cron/systemd-cron/issues/173#issuecomment-3261758772 for demo and diagram.
+ *
+ * self_object := $(GetUnitByPID $$)
+ * ListUnitsByPatterns("cron-*.service")
+ * | filter(load_state = "loaded")
+ * | filter(name !~ "@")                                       # filter out cron-mail@*
+ * | filter(object != $self_object)                            # deadlock against self
+ * | map(object.get-property(ExecStartPre)) &
+ * | filter(ExecStartPre.argv ~ ^[$0, $group, ...])
+ * if((active_state = "activating" && active_sub_state != "start-pre") || # Type=oneshot is always activating and never active
+ *                                                                        # activating + start-pre means running ExecStartPre=,
+ *                                                                        # which we need to exclude to not deadlock against other throttle_groups
+ *    active_state ∈ {"active", "reloading"})                  # reloading is a special type of active
+ * | | sleep(BLANKING_INTERVAL)                                # a unit from our group is currently running
+ * | ^ short-circuit back to top
+ * |
+ * | map(object.get-property(ExecMainStartTimestampMonotonic)) &
+ * | map(object.get-property(ExecMainExitTimestampMonotonic))  &
+ * if(ExecMainStartTimestampMonotonic > ExecMainExitTimestampMonotonic)
+ * | | sleep(BLANKING_INTERVAL)                                # a unit from our group is currently running (race)
+ * | ^ short-circuit back to top
+ * |
+ * | map(min_sleep := BLANKING_INTERVAL - (now - ExecMainExitTimestampMonotonic))
+ * goal_sleep := reduce(max(min_sleep, 0))
+ *
+ * if(goal_sleep > 0)
+ *   | sleep(goal_sleep)                                       # a unit from our group was running less than 5 minutes ago, sleep out the remaining 5 minutes
+ *   ^ back to top
+ *
+ * if(!cmpxchg("/systemd-cron.throttle_group"))
+ *   | sleep(5s)                                               # a different throttle_group instance loosed a job while we were looking
+ *   ^ back to top
+ *
+ * exit to loose job
+ *
+ * All get-property queries are scatter-gather, and a short-circuit cancels outstanding orders.
+ */
+#if 0 /* clang-format off */
+[ $# -eq 1 ] || {
+	printf 'usage: %s group\n' "$0" >&2
+	exit 1
+}
+group="$1"
+
+# org.freedesktop.systemd1(5):
+#   ListUnitsByPatterns("cron-*.service")
+#   | filter(load_state="loaded")
+#   | filter(name !~ "@")                  # filter out cron-mail@*
+#   | flat_map(object.get-property(ExecMain{Start,Exit}TimestampMonotonic, ExecStartPre))
+#   | filter(ExecStartPre ~ '"$0" "$group"')
+#   | find(ExecStartPre ~ '"$0" "$group"')
+busctl --system call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager ListUnitsByPatterns asas 0 1 'cron-*.service' |
+	awk '{gsub(/\\"/, ""); gsub(/" ([0-9]*) "/, "\" \""); gsub(/" "/, "\"\n\""); gsub(/"/, ""); print}' |
+	while read -r name && read -r description && read -r load_state && read -r active_state && read -r active_sub_state && read -r following && read -r object && read -r job_type && read -r job_path; do
+		[ "$load_state" = "loaded" ] || continue
+		[ "${name%@*}"  = "$name"  ] || continue  # first name may have garbage on front (doesn't matter for this)
+		busctl --system get-property org.freedesktop.systemd1 "$object" org.freedesktop.systemd1.Service ExecMainStartTimestampMonotonic ExecMainExitTimestampMonotonic ExecStartPre | paste -s &
+	done | while read -r _ ExecMainStartTimestampMonotonic _ ExecMainExitTimestampMonotonic _ ExecStartPre; do
+		[ "${ExecStartPre%"\"$0\" \"$group\""*}" != "$ExecStartPre" ] || continue
+		echo ExecMainStartTimestampMonotonic=$ExecMainStartTimestampMonotonic
+		echo ExecMainExitTimestampMonotonic =$ExecMainExitTimestampMonotonic
+	done
+#endif /* clang-format on */
+
+#define SHMEM_FILE "systemd-cron.throttle_group"
+#include "shmemutil.hpp"
+#include <forward_list>
+#include <memory>
+#include <numeric>
+#include <systemd/sd-bus.h>
+
+
+namespace {
+	const constexpr struct timespec BLANKING_INTERVAL{5 * 60, 0};
+
+
+	auto sd_bus_get_property_async(sd_bus * bus, sd_bus_slot ** slot, const char * destination, const char * path, const char * interface, const char * member,
+	                               sd_bus_message_handler_t callback, void * userdata) -> int {
+		return sd_bus_call_method_async(bus, slot, destination, path, "org.freedesktop.DBus.Properties", "Get", callback, userdata, "ss", interface, member);
+	}
+
+	struct sd_bus_message_deleter {
+		void operator()(sd_bus_message * m) const noexcept { sd_bus_message_unref(m); }
+	};
+
+	struct sd_bus_slot_deleter {
+		void operator()(sd_bus_slot * m) const noexcept { sd_bus_slot_unref(m); }
+	};
+
+
+	std::string_view self, group;
+	sd_bus * bus;
+	struct timespec now;
+	struct listed_unit * winner;
+	struct listed_unit {
+		const char *object, *active_state, *active_sub_state;
+		std::unique_ptr<sd_bus_slot, sd_bus_slot_deleter> slot, ExecMainStartTimestampMonotonic_slot, ExecMainExitTimestampMonotonic_slot;
+		std::optional<struct timespec> ExecMainStartTimestampMonotonic, ExecMainExitTimestampMonotonic;
+		struct timespec result;
+
+		auto ExecMainOneTimestampMonotonic(sd_bus_message * m, std::optional<struct timespec> listed_unit::* member) -> int {
+			if(auto err = sd_bus_message_enter_container(m, 'v', "t"); err < 0)
+				return err;
+
+			std::uint64_t usec;
+			if(auto err = sd_bus_message_read(m, "t", &usec); err < 0)
+				return err;
+
+			(this->*member).emplace();
+			(this->*member)->tv_sec  = usec / 1'000'000;
+			(this->*member)->tv_nsec = (usec - ((this->*member)->tv_sec * 1'000'000)) * 1'000;
+
+			if(this->ExecMainStartTimestampMonotonic && this->ExecMainExitTimestampMonotonic) {
+				if(*this->ExecMainStartTimestampMonotonic > *this->ExecMainExitTimestampMonotonic) {  // should've been caught by active_state check
+					this->result = BLANKING_INTERVAL;
+					winner       = this;
+				} else
+					this->result = BLANKING_INTERVAL - (now - *this->ExecMainExitTimestampMonotonic);
+			}
+			return 0;
+		}
+	};
+}
+
+
+auto main(int, const char * const * argv) -> int {
+	self = *argv++;
+	if(*argv && *argv == "--"sv)
+		++argv;
+	if(!*argv || *(argv + 1))
+		return std::fprintf(stderr, "usage: %s group\n", self.data()), 1;
+	group = *argv;
+
+
+	shm_t * shm;
+	if(auto err = bundle::map(self.data(), shm))
+		return err;
+
+	if(auto err = sd_bus_default_system(&bus); err < 0)
+		return std::fprintf(stderr, "%s: %s\n", self.data(), std::strerror(-err)), 1;
+
+	const auto pid = getpid();
+	std::string_view self_object;
+	{
+		sd_bus_message * self_object_m;  // we leak this to get it for static lifetime
+		if(sd_bus_error err{}; sd_bus_call_method(bus, "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "GetUnitByPID",
+		                                          &err, &self_object_m, "u", static_cast<unsigned>(pid)) < 0)
+			return std::fprintf(stderr, "%s: %s: %s\n", self.data(), err.message, err.name), 1;
+
+		const char * self_object_s;
+		if(auto err = sd_bus_message_read(self_object_m, "o", &self_object_s); err <= 0)
+			return std::fprintf(stderr, "%s: %s\n", self.data(), std::strerror(-err)), 1;
+		self_object = self_object_s;
+	}
+
+	for(;;) {
+		const auto last = shm->load();
+		clock_gettime(CLOCK_MONOTONIC_COARSE, &now);
+
+		sd_bus_message * units_r;
+		if(sd_bus_error err{}; sd_bus_call_method(bus, "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager",
+		                                          "ListUnitsByPatterns", &err, &units_r, "asas", 0u, 1u, "cron-*.service") < 0)
+			return std::fprintf(stderr, "%s: %s: %s\n", self.data(), err.message, err.name), 1;
+		std::unique_ptr<sd_bus_message, sd_bus_message_deleter> units{units_r};
+		sd_bus_message_enter_container(units.get(), 'a', "(ssssssouso)");
+
+		winner = {};
+		std::forward_list<listed_unit> listed_units;
+		for(;;) {
+			const char *name, *description, *load_state, *active_state, *active_sub_state, *following, *object, *job_type, *job_path;
+			uint32_t job_id;
+			if(auto err = sd_bus_message_read(units.get(), "(ssssssouso)", &name, &description, &load_state, &active_state, &active_sub_state, &following, &object,
+			                                  &job_id, &job_type, &job_path);
+			   err <= 0 && err != -EBUSY) {
+				if(err == 0)
+					break;
+				return std::fprintf(stderr, "%s: %s\n", self.data(), std::strerror(-err)), 1;
+			}
+
+			if(std::strchr(name, '@') || load_state != "loaded"sv)
+				continue;
+			if(object == self_object)
+				continue;
+
+			auto & unit           = listed_units.emplace_front();
+			unit.object           = object;
+			unit.active_state     = active_state;
+			unit.active_sub_state = active_sub_state;
+			sd_bus_slot * slot;
+			if(sd_bus_get_property_async(
+			       bus, &slot, "org.freedesktop.systemd1", object, "org.freedesktop.systemd1.Service", "ExecStartPre",
+			       [](sd_bus_message * m, void * userdata, sd_bus_error *) {
+				       auto & unit = *static_cast<listed_unit *>(userdata);
+
+				       if(auto err = sd_bus_message_enter_container(m, 'v', "a(sasbttttuii)"); err < 0)
+					       return err;
+				       if(auto err = sd_bus_message_enter_container(m, 'a', "(sasbttttuii)"); err < 0)
+					       return err;
+
+				       while(!winner && !unit.ExecMainStartTimestampMonotonic_slot && !unit.ExecMainExitTimestampMonotonic_slot) {
+					       if(auto err = sd_bus_message_enter_container(m, 'r', "sasbttttuii"); err < 0)
+						       return err;
+
+					       const char * s;
+					       if(auto err = sd_bus_message_read(m, "s", &s); err <= 0)
+						       return err;
+
+					       if(auto err = sd_bus_message_enter_container(m, 'a', "s"); err < 0)
+						       return err;
+					       if(const char * argv[2]; sd_bus_message_read(m, "s", &argv[0]) > 0 && sd_bus_message_read(m, "s", &argv[1]) > 0) {
+						       if(argv[0] == self && argv[1] == group) {
+							       if((unit.active_state == "activating"sv && unit.active_sub_state != "start-pre"sv) ||  //
+							          unit.active_state == "active"sv || unit.active_state == "reloading"sv) {
+								       unit.result = BLANKING_INTERVAL;
+								       winner      = &unit;
+							       } else {
+								       sd_bus_slot *start{}, *exit{};
+								       sd_bus_get_property_async(
+								           bus, &start, "org.freedesktop.systemd1", unit.object, "org.freedesktop.systemd1.Service", "ExecMainStartTimestampMonotonic",
+								           [](sd_bus_message * m, void * userdata, sd_bus_error *) {
+									           return static_cast<listed_unit *>(userdata)->ExecMainOneTimestampMonotonic(m, &listed_unit::ExecMainStartTimestampMonotonic);
+								           },
+								           &unit);
+								       sd_bus_get_property_async(
+								           bus, &exit, "org.freedesktop.systemd1", unit.object, "org.freedesktop.systemd1.Service", "ExecMainExitTimestampMonotonic",
+								           [](sd_bus_message * m, void * userdata, sd_bus_error *) {
+									           return static_cast<listed_unit *>(userdata)->ExecMainOneTimestampMonotonic(m, &listed_unit::ExecMainExitTimestampMonotonic);
+								           },
+								           &unit);
+								       unit.ExecMainStartTimestampMonotonic_slot.reset(start);
+								       unit.ExecMainExitTimestampMonotonic_slot.reset(exit);
+							       }
+						       }
+
+						       while(sd_bus_message_read(m, "s", &s) == -EBUSY)
+							       ;
+					       }
+					       if(auto err = sd_bus_message_exit_container(m); err <= 0)
+						       return err;
+
+					       if(auto err = sd_bus_message_skip(m, "bttttuii"); err <= 0)
+						       return err;
+					       if(auto err = sd_bus_message_exit_container(m); err <= 0)
+						       return err;
+				       }
+
+				       return 0;
+			       },
+			       &unit) < 0)
+				continue;
+			unit.slot.reset(slot);
+		}
+
+		for(int err; !winner && (err = sd_bus_process(bus, nullptr));) {
+			if(err < 0 || (err = sd_bus_wait(bus, 1'000 /* 1ms */)) < 0)
+				return std::fprintf(stderr, "%s: %s\n", self.data(), std::strerror(-err)), 1;
+		}
+		if(winner) {  // we decisively know how long to sleep for (because a unit from our group is running)
+			            // listed_units going out of scope cancels pending request slots in case we short-circuited
+			nanosleep(&winner->result, nullptr);
+			continue;
+		}
+		if(auto sleep = std::accumulate(std::begin(listed_units), std::end(listed_units), (struct timespec){},
+		                                [](auto && acc, auto && unit) { return unit.result > acc ? unit.result : acc; });
+		   sleep.tv_sec || sleep.tv_nsec) {  // a unit from our group exited less than BLANKING_INTERVAL ago, sleep for the remaining time
+			nanosleep(&sleep, nullptr);
+			continue;
+		}
+
+		if(auto value = last; !shm->compare_exchange_strong(value, {pid, now})) {
+			sleep(5);  // someone else did something in the mean-time, look again
+			continue;
+		}
+
+		break;
+	}
+}

--- a/src/include/configuration.hpp.in
+++ b/src/include/configuration.hpp.in
@@ -5,7 +5,8 @@ static const char * const VERSION                       = "@version@";
 static const constexpr std::string_view USE_LOGLEVELMAX = "@use_loglevelmax@"sv;
 static const constexpr bool USE_RUNPARTS                = @use_runparts@;
 static const constexpr bool HAVE_ONSUCCESS              = @have_onsuccess@;
-static const constexpr std::string_view BOOT_DELAY      = "@libexecdir@/systemd-cron/boot_delay"sv;
+static const char * const BOOT_DELAY                    = "@libexecdir@/systemd-cron/boot_delay";
+static const char * const LOADAVG_DAM                   = "@libexecdir@/systemd-cron/loadavg_dam";
 #define STATEDIR "@statedir@"
 static const char * const SETGID_HELPER                 = "@libexecdir@/systemd-cron/crontab_setgid";
 #define PAMNAME "@pamname@"  // ignore if empty

--- a/src/include/configuration.hpp.in
+++ b/src/include/configuration.hpp.in
@@ -7,6 +7,7 @@ static const constexpr bool USE_RUNPARTS                = @use_runparts@;
 static const constexpr bool HAVE_ONSUCCESS              = @have_onsuccess@;
 static const char * const BOOT_DELAY                    = "@libexecdir@/systemd-cron/boot_delay";
 static const char * const LOADAVG_DAM                   = "@libexecdir@/systemd-cron/loadavg_dam";
+static const char * const THROTTLE_GROUP                = "@libexecdir@/systemd-cron/throttle_group";
 #define STATEDIR "@statedir@"
 static const char * const SETGID_HELPER                 = "@libexecdir@/systemd-cron/crontab_setgid";
 #define PAMNAME "@pamname@"  // ignore if empty

--- a/src/include/libvoreutils.hpp
+++ b/src/include/libvoreutils.hpp
@@ -436,4 +436,41 @@ namespace vore {
 		overload(Ts...) -> overload<Ts...>;
 	}
 }
+
+
+namespace vore {
+	namespace {
+		[[maybe_unused]]
+		const char * parse_floating(const char * val, double & out) {
+			char * end{};
+			errno = 0;
+			out   = std::strtod(val, &end);
+			if(out == 0 && end == val)
+				return "invalid";
+			else if(end && *end)
+				return "partial conversion";
+			else if(errno)
+				return std::strerror(errno);
+
+			return std::isnan(out) ? "is NaN" : nullptr;
+		}
+	}
+}
+
+
+[[maybe_unused]]
+constexpr static bool operator>(const struct timespec & lhs, const struct timespec & rhs) {
+	return lhs.tv_sec > rhs.tv_sec || (lhs.tv_sec == rhs.tv_sec && lhs.tv_nsec > rhs.tv_nsec);
+}
+
+[[maybe_unused]]
+constexpr static struct timespec operator-(struct timespec lhs, const struct timespec & rhs) {
+	if(rhs.tv_nsec > lhs.tv_nsec) {
+		lhs.tv_sec -= 1;
+		lhs.tv_nsec += 1'000'000'000;
+	}
+	lhs.tv_nsec -= rhs.tv_nsec;
+	lhs.tv_sec -= rhs.tv_sec;
+	return lhs;
+}
 #endif

--- a/src/include/shmemutil.hpp
+++ b/src/include/shmemutil.hpp
@@ -1,0 +1,49 @@
+/* Copyright (C) 2025 наб (nabijaczleweli@nabijaczleweli.xyz)
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include "libvoreutils.hpp"
+#include <atomic>
+#include <type_traits>
+
+namespace {
+	struct bundle {
+		// All-0 is a valid initial state for this, so ftruncate() is a valid initialiser
+		using shm_t = std::atomic<struct bundle>;
+
+		static const constexpr std::size_t PIDBITS    = 22;  // 2^22 is the current max max (but any max is ok)
+		static const constexpr std::size_t SUBSECBITS = 64 - 32 - PIDBITS;
+		std::uint64_t last_winner : PIDBITS;   // the process that was dispatched
+		std::uint64_t last_time_won_sec : 32;  // last time a process was dispatched
+		std::uint64_t last_time_won_subsec : SUBSECBITS;
+
+		bundle(pid_t pid, const struct timespec & now)
+		      : last_winner(0), last_time_won_sec(now.tv_sec),
+		        last_time_won_subsec(static_cast<std::uint64_t>(now.tv_nsec) * (1llu << SUBSECBITS) / 1'000'000'000) {
+			std::make_unsigned_t<pid_t> pidbits = pid;
+			for(int left = sizeof(pidbits) * 8; left > 0; left -= PIDBITS, pidbits >>= PIDBITS)
+				this->last_winner ^= pidbits & ((1u << PIDBITS) - 1);
+		}
+
+		operator struct timespec() const { return {this->last_time_won_sec, this->last_time_won_subsec}; }
+
+		static auto map(const char * self, shm_t *& shm) -> int {
+			auto shm_f = shm_open("/" SHMEM_FILE, O_RDWR | O_CREAT, 0644);
+			if(shm_f == -1)
+				return std::fprintf(stderr, "%s: %s: %s\n", self, "/" SHMEM_FILE, std::strerror(errno)), 1;
+
+			if(ftruncate(shm_f, sizeof(shm_t)))
+				return std::fprintf(stderr, "%s: %s\n", self, std::strerror(errno)), 1;
+
+			shm = static_cast<shm_t *>(mmap(nullptr, sizeof(shm_t), PROT_READ | PROT_WRITE, MAP_SHARED, shm_f, 0));
+			if(shm == MAP_FAILED)
+				return std::fprintf(stderr, "%s: %s\n", self, std::strerror(errno)), 1;
+
+			close(shm_f);
+			return 0;
+		}
+	};
+	static_assert(sizeof(bundle) == sizeof(std::uint64_t));
+
+	using shm_t = bundle::shm_t;
+}

--- a/src/lib/tmpfiles.d/systemd-cron.conf
+++ b/src/lib/tmpfiles.d/systemd-cron.conf
@@ -1,0 +1,1 @@
+f /dev/shm/systemd-cron 0644 root root

--- a/src/lib/tmpfiles.d/systemd-cron.conf
+++ b/src/lib/tmpfiles.d/systemd-cron.conf
@@ -1,1 +1,2 @@
-f /dev/shm/systemd-cron 0644 root root
+f /dev/shm/systemd-cron.loadavg_dam    0644 root root
+f /dev/shm/systemd-cron.throttle_group 0644 root root

--- a/src/man/crontab.5.in
+++ b/src/man/crontab.5.in
@@ -227,6 +227,11 @@ and
 .B IOSchedulingClass=idle
 when set.
 
+.TP
+.B CRON_BATCH_LOADAVG_BELOW
+If set and nonempty, delay starting the job until the 1-minute system load average drops below the set value.
+All jobs using this option join a global queue scheduling a random eligible job every 30 seconds.
+
 .PP
 The format of a
 .B cron command

--- a/src/man/crontab.5.in
+++ b/src/man/crontab.5.in
@@ -232,6 +232,12 @@ when set.
 If set and nonempty, delay starting the job until the 1-minute system load average drops below the set value.
 All jobs using this option join a global queue scheduling a random eligible job every 30 seconds.
 
+.TP
+.B CRON_BATCH_THROTTLE_GROUP
+If set and nonempty, all jobs with the same value form a group where
+no two jobs can run concurrently,
+no job is started within 5 minutes of another exiting.
+
 .PP
 The format of a
 .B cron command

--- a/src/man/systemd.cron.7.in
+++ b/src/man/systemd.cron.7.in
@@ -55,9 +55,11 @@ System crontabs managed by packages live here.
 .It Pa @statedir@
 Users' crontabs live here.
 .
-.It Pa /dev/shm/systemd-cron
-Queue used for
-.Sy CRON_BATCH_LOADAVG_BELOW .
+.It Pa /dev/shm/systemd-cron. Ns Va *
+Queues and tokens used for
+.Sy CRON_BATCH_LOADAVG_BELOW
+and
+.Sy CRON_BATCH_THROTTLE_GROUP .
 .
 .Pp
 .de etccron

--- a/src/man/systemd.cron.7.in
+++ b/src/man/systemd.cron.7.in
@@ -55,6 +55,10 @@ System crontabs managed by packages live here.
 .It Pa @statedir@
 Users' crontabs live here.
 .
+.It Pa /dev/shm/systemd-cron
+Queue used for
+.Sy CRON_BATCH_LOADAVG_BELOW .
+.
 .Pp
 .de etccron
 .if \\n[etccron_\\$1] \{ .

--- a/test/test-generator
+++ b/test/test-generator
@@ -106,6 +106,11 @@ assert_dat() {  # file content testname
 	              'CRON_MAIL_FORMAT=inherit'                                  \
 	              '* * * * * dummy :'                                         \
 	              'CRON_MAIL_FORMAT=no-metadata'                              \
+	              '* * * * * dummy :'                                         \
+	                                                                          \
+	              'CRON_BATCH_LOADAVG_BELOW=10'                               \
+	              '* * * * * dummy :'                                         \
+	              'CRON_BATCH_LOADAVG_BELOW='                                 \
 	              '* * * * * dummy :'                                         > /etc/crontab
 	printf '%s\n' '# test_MAIL_inherit_default'                               \
 	              '* * * * * dummy !'                                         \
@@ -188,6 +193,11 @@ assert_dat() {  # file content testname
 	assert_key cron-crontab-dummy-18.service 'OnFailure' 'cron-mail@%n:Failure.service'                     test_cron_mail_format=inherit
 	assert_key cron-crontab-dummy-19.service 'OnSuccess' 'cron-mail@%n:Success:nonempty:nometadata.service' test_cron_mail_format=no-metadata
 	assert_key cron-crontab-dummy-19.service 'OnFailure' 'cron-mail@%n:Failure:nometadata.service'          test_cron_mail_format=no-metadata
+	assert_ney cron-crontab-dummy-19.service 'TimeoutStartSec'                                              test_cron_mail_format=no-metadata
+	assert_key cron-crontab-dummy-20.service 'ExecStartPre'    "!/usr/libexec/systemd-cron/loadavg_dam 10"  test_cron_batch_loadavg_below=10
+	assert_key cron-crontab-dummy-20.service 'TimeoutStartSec' 'infinity'                                   test_cron_batch_loadavg_below=10
+	assert_ney cron-crontab-dummy-21.service 'ExecStartPre'                                                 test_cron_batch_loadavg_below=10
+	assert_ney cron-crontab-dummy-21.service 'TimeoutStartSec'                                              test_cron_batch_loadavg_below=10
 
 	assert_key cron-crondtab-dummy-0.service 'OnSuccess' 'cron-mail@%n:Success:nonempty:nometadata.service' test_MAIL_inherit_default
 	assert_key cron-crondtab-dummy-0.service 'OnFailure' 'cron-mail@%n:Failure:nometadata.service'          test_MAIL_inherit_default
@@ -342,6 +352,7 @@ then
 
 	assert_key cron-daily-id.service  'Description'       '[Cron] /etc/cron.daily/id'                /etc/cron.daily
 	assert_key cron-daily-id.service  'ExecStartPre'      '-/usr/libexec/systemd-cron/boot_delay 10' /etc/cron.daily    # hourly.daily = 2nd, *5min for each longer one
+	assert_key cron-daily-id.service  'TimeoutStartSec'   'infinity'                                 /etc/cron.daily
 	assert_key cron-daily-id.service  'ExecStart'         '/etc/cron.daily/id'                       /etc/cron.daily
 	assert_key cron-daily-id.timer    'OnCalendar'        '*-*-* 5:10:0'                             /etc/cron.daily
 	assert_key cron-daily-id.timer    'Persistent'        'true'                                     /etc/cron.daily


### PR DESCRIPTION
(CRON_BATCH_THROTTLE_GROUP= works as in #174, q.v.)

`CRON_BATCH_THROTTLE_GROUP=$group` generates `ExecStartPre=!/.../throttle_group $group`: multiple optionally-concurrent throttle_group processes with the same `$group` form a global persistent queue which waits until it's been 5 minutes since the last job with `CRON_BATCH_THROTTLE_GROUP=$group` exited, then spawns a random one from the queue (no two jobs from the same group can run concurrently).

If I understood #173 right, this should cover @pabs3's case, described in https://github.com/systemd-cron/systemd-cron/issues/173#issuecomment-3261758772.