### PR TITLE
Use MAILFROM from service Environment as a default

### DIFF
--- a/src/bin/mail_for_job.sh
+++ b/src/bin/mail_for_job.sh
@@ -50,7 +50,7 @@ systemctl show --property=User --property=Environment --property=SourcePath --pr
 
 	export user  # used by custom sendmails!
 	mailto="$user"
-	mailfrom='root'
+	mailfrom="${MAILFROM:-root}"
 
 	sendmail="$SENDMAIL"
 	for kv in $job_env; do


### PR DESCRIPTION
There are multiple cases where `MAILFROM=root` is unsuitable. In theses cases an administrator could:
- Either hook at MTA's level to transform `From`
- Set the individual `MAILFROM` for each of its cron jobs

This change allows the administrator to set the `MAILFROM` in the service unit (or any other relevant file like `/etc/anacrontab` or `/etc/cron`) to act as a default (instead of root) and avoid individual cron jobs modification.
